### PR TITLE
Only match active VPC peering connections

### DIFF
--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -194,6 +194,7 @@ in {
 
     data.aws_vpc_peering_connection = lib.flip lib.mapAttrs' vpcs (region: vpc:
       lib.nameValuePair region {
+        status = "active";
         tags = {
           Name = vpc.name;
           Side = "accepter";


### PR DESCRIPTION
Fix https://github.com/input-output-hk/bitte/issues/1 by limiting data source query to active VPC peering connections.