### PR TITLE
Remove seaweedfs from telegraf

### DIFF
--- a/profiles/telegraf.nix
+++ b/profiles/telegraf.nix
@@ -33,7 +33,8 @@ in {
         };
 
         prometheus = {
-          urls = [ "http://127.0.0.1:3101/metrics" "http://127.0.0.1:9334" ];
+          #urls = [ "http://127.0.0.1:3101/metrics" "http://127.0.0.1:9334" ];
+          urls = [ "http://127.0.0.1:3101/metrics" ];
           metric_version = 2;
         };
 


### PR DESCRIPTION
It's been removed from everywhere else and is cauing errors in the logs