### PR TITLE
Make Docker containers resolve domains using the hosts dnsmasq

### DIFF
--- a/profiles/docker.nix
+++ b/profiles/docker.nix
@@ -1,4 +1,4 @@
-{ ... }: {
+{ lib, ... }: {
   virtualisation.docker = {
     enable = true;
     autoPrune = {
@@ -6,9 +6,15 @@
       dates = "daily";
     };
 
-    extraOptions = ''
-      --log-driver=journald
-    '';
+    extraOptions = lib.concatStringsSep " " [
+      "--log-driver=journald"
+      # For simplicity, let the bridge network have a static ip/mask (by default it
+      # would choose this one, but fall back to the next range if this one is already used)
+      "--bip=172.17.0.1/16"
+      # Which allows us to specify that containers should use the local host as the DNS server
+      # This is written into the containers /etc/resolv.conf
+      "--dns=172.17.0.1"
+    ];
   };
 
   # needed to access AWS meta-data after docker starts veth* devices.
@@ -16,4 +22,10 @@
     address = "169.254.169.252";
     prefixLength = 30;
   }];
+
+  # Allow docker containers to issue DNS queries to the local host, which runs dnsmasq,
+  # which allows them to resolve consul service domains as described in https://www.consul.io/docs/discovery/dns
+  networking.firewall.extraCommands = ''
+    iptables -A INPUT -i docker0 -p udp -m udp --dport 53 -j ACCEPT
+  '';
 }


### PR DESCRIPTION
Currently, the `/etc/resolv.conf` in Docker containers just points to 127.0.0.1, which doesn't resolve any DNS queries, since (at least in the default `bridge` network mode) this points to the containers ip.

This PR makes containers use the host for DNS lookups, which notably also allows resolving [consul DNS queries](https://www.consul.io/docs/discovery/dns).

Note that I only tested this with a local Docker daemon, not with the full bitte stack. It could be the case that the [`dns`](https://www.nomadproject.io/docs/job-specification/network#network-parameters) taskgroup paremeter's default of "all DNS configuration is inherited from the client host" overrides the Docker daemon's default specified with `--dns`. In that case, Nomad taskgroups will just have to set that parameter to the same address as here. Nevertheless, containers started outside of Nomad will use the `--dns` default for sure.