### PR TITLE
Skopeo improvements

### DIFF
--- a/lib/run-nomad-job.nix
+++ b/lib/run-nomad-job.nix
@@ -1,5 +1,5 @@
 { name, lib, json, dockerImages, writeShellScriptBin, vault-bin, awscli
-, coreutils, jq, nomad, consul, nixFlakes, docker, curl, gnugrep, gitMinimal
+, coreutils, jq, nomad, consul, nixFlakes, curl, gnugrep, gitMinimal
 , skopeo }:
 let
   pushImage = imageId: image:
@@ -39,7 +39,6 @@ in writeShellScriptBin "nomad-run" ''
       curl
       gnugrep
       gitMinimal
-      docker
     ]
   }"
   echo "running job: ${json}"
@@ -100,8 +99,6 @@ in writeShellScriptBin "nomad-run" ''
 
   ${lib.optionalString ((builtins.length pushImages) > 0) ''
     dockerPassword="$(vault kv get -field value kv/nomad-cluster/docker-developer-password)"
-    domain="$(nix eval ".#clusters.$BITTE_CLUSTER.proto.config.cluster.domain" --raw)"
-    echo "$dockerPassword" | docker login "docker.$domain" -u developer --password-stdin
   ''}
 
   ${builtins.concatStringsSep "\n" pushImages}

--- a/lib/run-nomad-job.nix
+++ b/lib/run-nomad-job.nix
@@ -21,7 +21,8 @@ let
         ${skopeo}/bin/skopeo copy \
           "docker-archive://$storePath" \
           "docker://${registry}/${repo}:${image.imageTag}" \
-          --dest-creds "developer:$dockerPassword"
+          --dest-creds "developer:$dockerPassword" \
+          --insecure-policy
       fi
     '';
   pushImages = lib.mapAttrsToList pushImage dockerImages;

--- a/lib/run-nomad-job.nix
+++ b/lib/run-nomad-job.nix
@@ -20,7 +20,7 @@ let
         })"
         ${skopeo}/bin/skopeo copy \
           "docker-archive://$storePath" \
-          "docker://${registry}/${repo}/${image.imageName}:${image.imageTag}" \
+          "docker://${registry}/${repo}:${image.imageTag}" \
           --dest-creds "developer:$dockerPassword"
       fi
     '';


### PR DESCRIPTION
Improvements on 8c822e79e3a4d6e07f8ccbd05aa809e41d5f3142, mentioned in https://github.com/input-output-hk/bitte/issues/16

- Docker isn't necessary anymore after 8c822e79e3a4d6e07f8ccbd05aa809e41d5f3142
- Without neither --insecure-policy or /etc/containers/policy.json,
  skopeo fails to upload images
  The insecure policy just means that it accepts any image without doing
  signature checks, see https://github.com/containers/image/blob/master/docs/containers-policy.json.5.md#insecureacceptanything
  for more info