### PR TITLE
Parse "sev" fields in journald output as log level

### DIFF
--- a/modules/promtail.nix
+++ b/modules/promtail.nix
@@ -92,6 +92,17 @@ let
             target_label = "image_name";
           }
         ];
+
+        pipeline_stages = [
+          {
+            json.expressions = {
+              sev = "sev";
+            };
+          }
+          {
+            labels.level = [ "level" "sev" ];
+          }
+        ];
       }
     ];
   };


### PR DESCRIPTION
Haskell's iohk-monitoring library uses Katip to output messages, which
uses "sev" for the severity of structured messages. We need to transform
this to "level" for promtail to discover it as such.

See https://grafana.com/docs/grafana/latest/explore/logs-integration/#log-level
for how a "level" label turns into the displayed severity

See https://grafana.com/docs/loki/latest/clients/promtail/configuration/#pipeline_stages
for docs on how pipeline_stages can be configured to assign labels based
on parsed messages

:warning: Warning: This is yet entirely untested.