### PR TITLE
Fix sg 400 errors on non-unique cidr_blocks

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -247,7 +247,7 @@ in final: prev: {
 
         from-cidr = (lib.nameValuePair
           "${prefix}-${rule.type}-${protocol}-${rule.name}-cidr"
-          (common // { cidr_blocks = rule.cidrs; }));
+          (common // { cidr_blocks = lib.unique rule.cidrs; }));
 
         from-ssgi = (lib.nameValuePair
           "${prefix}-${rule.type}-${protocol}-${rule.name}-ssgi" (common // {


### PR DESCRIPTION
* Avoids errors of:
```
Error: Error authorizing security group rule type ingress: InvalidParameterValue: 
The same permission must not appear multiple times
 status code: 400
```