### PR TITLE
Fixups

### DIFF
--- a/profiles/monitoring/consul.json
+++ b/profiles/monitoring/consul.json
@@ -1189,13 +1189,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg_over_time(consul_dns_domain_query_count[1h]) default 0",
+          "expr": "avg_over_time(union(consul_dns_domain_query_count,label_set(0,\"host\",\"baseline\"))[1h]) default 0",
           "interval": "",
           "legendFormat": "{{host}}",
           "refId": "A"
         },
         {
-          "expr": "sum(avg_over_time(consul_dns_domain_query_count{host=~\"core.*\"}[1h])) default 0",
+          "expr": "sum(avg_over_time(union(consul_dns_domain_query_count{host=~\"core.*\"},label_set(0,\"host\",\"baseline\"))[1h])) default 0",
           "hide": false,
           "interval": "",
           "legendFormat": "core-node-sum",

--- a/profiles/monitoring/consul.json
+++ b/profiles/monitoring/consul.json
@@ -1102,42 +1102,6 @@
       "type": "row"
     },
     {
-      "alert": {
-        "alertRuleTags": {},
-        "conditions": [
-          {
-            "evaluator": {
-              "params": [
-                0.1
-              ],
-              "type": "lt"
-            },
-            "operator": {
-              "type": "and"
-            },
-            "query": {
-              "params": [
-                "B",
-                "5m",
-                "now"
-              ]
-            },
-            "reducer": {
-              "params": [],
-              "type": "avg"
-            },
-            "type": "query"
-          }
-        ],
-        "executionErrorState": "alerting",
-        "for": "5m",
-        "frequency": "1m",
-        "handler": 1,
-        "message": "Average DNS queries from core nodes over the past hour is less than 1.\nThe consul servers may not be functioning correctly (ex: dnsmasq service).",
-        "name": "[Consul] DNS core queries alert",
-        "noDataState": "alerting",
-        "notifications": []
-      },
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -21,7 +21,7 @@
 
     serviceConfig = {
       Type = "oneshot";
-      RemainAfterExit = true;
+      RemainAfterExit = false;
       Restart = "on-failure";
       RestartSec = "30s";
     };


### PR DESCRIPTION
* Remove Grafana Consul low DNS alerts now that DNSmasq has auto-restart and mem-limit (https://github.com/input-output-hk/bitte/commit/9eeb21530930a9c9d04cc2d5f7888ac612aee160)
* Fixup for browser `SEC_ERROR_REVOKED_CERTIFICATE` errors on Firefox, Safari, etc, on ACME cert regeneration.