### PR TITLE
Fixes VPC issues caused by using asgSuffix in bitte ops repos

### DIFF
--- a/modules/terraform/network.nix
+++ b/modules/terraform/network.nix
@@ -13,7 +13,7 @@ let
   # https://docs.aws.amazon.com/vpc/latest/peering/peering-configurations-full-access.html#one-to-many-vpcs-full-access
 
   # Generate a region sorted list with the assumption of only 1 vpc per region
-  vpcRegions = lib.sort (a: b: a < b) (mapVpcsToList (vpc: vpc.region));
+  vpcRegions = lib.unique (lib.sort (a: b: a < b) (mapVpcsToList (vpc: vpc.region)));
 
   # The following definitions prepare a mesh of unique peeringPairs,
   # each with a connector and acceptor.  The following is an example of


### PR DESCRIPTION
* Enables creating bitte autoscaling groups in the same region and machine type by differentiating with an `asgSuffix`
* See example at: https://github.com/input-output-hk/erc20-ops/commit/c83e1cf935f324ed45def602ee87edd4e1525637