### PR TITLE
Bitte stack bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,17 +74,17 @@
     },
     "nixpkgs-terraform": {
       "locked": {
-        "lastModified": 1620395313,
-        "narHash": "sha256-zaNy1ZD0WNKon3ZmEEte7z74CE6PWmQ8XltwuTMGDMI=",
-        "owner": "manveru",
-        "repo": "nixpkgs",
-        "rev": "316b82563a7793a4a88bed9e41adb936d9adc969",
+        "lastModified": 1623438013,
+        "narHash": "sha256-H6vuv1WbNppuGMngGbwtgp5/9izMLvc88n1OVUrc6ug=",
+        "owner": "johnalotoski",
+        "repo": "nixpkgs-terraform",
+        "rev": "976b4e77144f6a28d856b7fabf97d03f49b7a0a1",
         "type": "github"
       },
       "original": {
-        "owner": "manveru",
-        "ref": "updated-terraform-providers",
-        "repo": "nixpkgs",
+        "owner": "johnalotoski",
+        "ref": "iohk-terraform-2021-06",
+        "repo": "nixpkgs-terraform",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -76,15 +76,15 @@
       "locked": {
         "lastModified": 1623440955,
         "narHash": "sha256-4hM9akwZ2RojC1CT5geV4IZhek/fUPpFitb5ItdoK5s=",
-        "owner": "johnalotoski",
-        "repo": "nixpkgs-terraform",
+        "owner": "input-output-hk",
+        "repo": "nixpkgs",
         "rev": "f94bea476f46784adf587e1cb3a5af9587fe9652",
         "type": "github"
       },
       "original": {
-        "owner": "johnalotoski",
+        "owner": "input-output-hk",
         "ref": "iohk-terraform-2021-06",
-        "repo": "nixpkgs-terraform",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
     },
     "nixpkgs-terraform": {
       "locked": {
-        "lastModified": 1623438013,
-        "narHash": "sha256-H6vuv1WbNppuGMngGbwtgp5/9izMLvc88n1OVUrc6ug=",
+        "lastModified": 1623440955,
+        "narHash": "sha256-4hM9akwZ2RojC1CT5geV4IZhek/fUPpFitb5ItdoK5s=",
         "owner": "johnalotoski",
         "repo": "nixpkgs-terraform",
-        "rev": "976b4e77144f6a28d856b7fabf97d03f49b7a0a1",
+        "rev": "f94bea476f46784adf587e1cb3a5af9587fe9652",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -138,16 +138,16 @@
     "nomad-source": {
       "flake": false,
       "locked": {
-        "lastModified": 1622657457,
-        "narHash": "sha256-gOs4hN4DaEoB9P1PBGguRVbloOZaY034tvcpsVcL9mo=",
+        "lastModified": 1623434122,
+        "narHash": "sha256-3cPp8STtTKMHtA2+rWqAjHVevAnUorRtZFWRnmaLLJc=",
         "owner": "input-output-hk",
         "repo": "nomad",
-        "rev": "ee73dd5b5a3641618cad70b99a64d110e627e505",
+        "rev": "1e35d887c0de086d344d7f9514eb0f63c3c68199",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "release-1.1.0",
+        "ref": "release-1.1.1",
         "repo": "nomad",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url =
       "github:NixOS/nixpkgs?rev=b8c367a7bd05e3a514c2b057c09223c74804a21b";
-    nixpkgs-terraform.url = "github:manveru/nixpkgs/updated-terraform-providers";
+    nixpkgs-terraform.url = "github:johnalotoski/nixpkgs-terraform/iohk-terraform-2021-06";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     utils.url = "github:numtide/flake-utils";
     bitte-cli.url = "github:input-output-hk/bitte-cli";

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url =
       "github:NixOS/nixpkgs?rev=b8c367a7bd05e3a514c2b057c09223c74804a21b";
-    nixpkgs-terraform.url = "github:johnalotoski/nixpkgs-terraform/iohk-terraform-2021-06";
+    nixpkgs-terraform.url = "github:input-output-hk/nixpkgs/iohk-terraform-2021-06";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     utils.url = "github:numtide/flake-utils";
     bitte-cli.url = "github:input-output-hk/bitte-cli";

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       flake = false;
     };
     nomad-source = {
-      url = "github:input-output-hk/nomad/release-1.1.0";
+      url = "github:input-output-hk/nomad/release-1.1.1";
       flake = false;
     };
     levant-source = {

--- a/modules/vault-agent-client.nix
+++ b/modules/vault-agent-client.nix
@@ -142,6 +142,9 @@ let
                 "consul": {
                   "token": "{{ .Data.token }}",
                   "address": "127.0.0.1:8500",
+                  "tlsCaFile": "/etc/ssl/certs/full.pem",
+                  "tlsCertFile": "/etc/ssl/certs/cert.pem",
+                  "tlsKeyFile": "/var/lib/vault/cert-key.pem"
                 }
               },
               "service_registration": {

--- a/pkgs/consul/default.nix
+++ b/pkgs/consul/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "consul";
-  version = "1.9.5";
+  version = "1.9.6";
   rev = "v${version}";
 
   # Note: Currently only release tags are supported, because they have the Consul UI
@@ -17,7 +17,7 @@ buildGoModule rec {
     owner = "hashicorp";
     repo = pname;
     inherit rev;
-    sha256 = "sha256-CKezHuCbL1I79gDz7ZQiSgPbSXo0NtssQro2MqqmeXw=";
+    sha256 = "sha256-SuG/Q5Tjet4etd4Qy5NBQLYEe2QO0K8QHKmgxYMl09U=";
   };
 
   patches = [
@@ -30,7 +30,7 @@ buildGoModule rec {
   # has a split module structure in one repo
   subPackages = [ "." "connect/certgen" ];
 
-  vendorSha256 = "sha256-YqrW3PeFv1Y6lmjVmMMP0SZao57iPqfut3a1afIWkI0=";
+  vendorSha256 = "sha256-ix1GMv0n7NrcSqqd5widTa+K3bg8lA43nZVGI8M0Cb4=";
   deleteVendor = true;
 
   preBuild = ''

--- a/pkgs/nomad.nix
+++ b/pkgs/nomad.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "nomad";
-  version = "1.1.0";
+  version = "1.1.1";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/nomad";

--- a/pkgs/vault-bin.nix
+++ b/pkgs/vault-bin.nix
@@ -1,21 +1,21 @@
 { stdenv, fetchurl, unzip, makeWrapper, gawk, glibc }:
 
 let
-  version = "1.6.0";
+  version = "1.7.2";
 
   sources = let base = "https://releases.hashicorp.com/vault/${version}";
   in {
     x86_64-linux = fetchurl {
       url = "${base}/vault_${version}_linux_amd64.zip";
-      sha256 = "sha256-gwSOLR6/6iEv6tQuR06UfDo7zMUFalFY7TP1MPgyXjk=";
+      sha256 = "sha256-Xua7gRm1XCfNOGTJghd3FKCko4E5J8yv2yYueOS7Z7w=";
     };
     x86_64-darwin = fetchurl {
       url = "${base}/vault_${version}_darwin_amd64.zip";
-      sha256 = "sha256-EOqQtR1muFSD0Weqtr3EOj4f/PpW9uJHhMCj08uYgUI=";
+      sha256 = "sha256-fTfhLMuUl6nkA9Vi2Dey6nuZ2+kZ5pVq3h4uQQpU9XM=";
     };
     aarch64-linux = fetchurl {
       url = "${base}/vault_${version}_linux_arm64.zip";
-      sha256 = "sha256-//E8f3U+vunr6ojoH12N+j1i8V6g765Ch/CaTkIsCgU=";
+      sha256 = "sha256-K7nUmyU4k/+iFJ7oXOLyvHI2CiwUrId1FV80xXI0RTM=";
     };
   };
 

--- a/profiles/vault/default.nix
+++ b/profiles/vault/default.nix
@@ -19,13 +19,6 @@ in {
     services.vault = {
       logLevel = "trace";
 
-      storage.consul = lib.mkDefault {
-        address = "127.0.0.1:8500";
-        tlsCaFile = full;
-        tlsCertFile = cert;
-        tlsKeyFile = key;
-      };
-
       seal.awskms = {
         kmsKeyId = kms;
         inherit region;

--- a/profiles/vault/server.nix
+++ b/profiles/vault/server.nix
@@ -1,7 +1,11 @@
-{ config, nodeName, ... }:
+{ config, nodeName, lib, ... }:
 let
   inherit (config.cluster) instances;
   inherit (instances.${nodeName}) privateIP;
+
+  full = "/etc/ssl/certs/full.pem";
+  cert = "/etc/ssl/certs/cert.pem";
+  key = "/var/lib/vault/cert-key.pem";
 in {
   imports = [ ./default.nix ./policies.nix ];
   config = {
@@ -13,6 +17,13 @@ in {
       clusterAddr = "https://${privateIP}:8201";
 
       listener.tcp = { clusterAddress = "${privateIP}:8201"; };
+
+      storage.consul = lib.mkDefault {
+        address = "127.0.0.1:8500";
+        tlsCaFile = full;
+        tlsCertFile = cert;
+        tlsKeyFile = key;
+      };
     };
   };
 }


### PR DESCRIPTION
* consul 1.9.5 -> 1.9.6
* nomad 1.1.0 -> 1.1.1 (fixes exec disconnect)
* vault 1.6.0 -> 1.7.2
* Fixup SAN cert support with acme 1.5.0-patched2 plugin
* Bumps tf plugins: consul -> 2.11.0, vault -> 2.18.0 (keeps aws @ 3.27.0)
* Fix up for go deep-merge and import determinism issue on /etc/vault.d