### PR TITLE
[Hydra] support toggling restricted/pure modes

### DIFF
--- a/modules/hydra-evaluator.nix
+++ b/modules/hydra-evaluator.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+with types;
+
+let
+  cfg = config.services.hydra.evaluator;
+in {
+  options.services.hydra.evaluator = {
+    restricted = (mkEnableOption "restricted evaluation mode") // { default = true; };
+    pure = mkEnableOption "pure evaluation mode";
+  };
+
+  config = mkIf config.services.hydra.enable {
+    services.hydra.extraConfig = ''
+      evaluator_restrict_eval = ${boolToString cfg.restricted}
+      evaluator_pure_eval = ${boolToString cfg.pure}
+    '';
+  };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -8,6 +8,21 @@ in final: prev: {
   # try to use Nix 2.3 with `--experimental-features` and thereby croak and die.
   nix = final.nixUnstable;
 
+  hydra-unstable = prev.hydra-unstable.overrideAttrs (oldAttrs: {
+    patches = (oldAttrs.patches or []) ++ [
+      # allow evaluator_restrict_eval to be configured
+      (prev.fetchpatch {
+        url = "https://github.com/NixOS/hydra/pull/888/commits/de203436cdbfa521ac3a231fafbcc7490c10766e.patch";
+        sha256 = "sha256-TCJEmTkycUWTx7U433jaGzKwpbCyNdXqiv9UfhsHnfs=";
+      })
+      # allow evaluator_pure_eval to be configured
+      (prev.fetchpatch {
+        url = "https://github.com/NixOS/hydra/pull/981/commits/24959a3ca6608cb1a1b11c2bf8436c800e5811f8.patch";
+        sha256 = "sha256-JXhmtI8IDjv6VAXwLwDoGnWywBbIbZYh4uFWlP5UdSU=";
+      })
+    ];
+  });
+
   ssm-agent = prev.callPackage ./pkgs/ssm-agent { };
 
   consul = prev.callPackage ./pkgs/consul { };


### PR DESCRIPTION
Basically copied the patching @jonringer did in `midnight-ops` and added `services.hydra.evaluator.{restricted,pure}` toggles to the module.

Edit: default is the old behaviour. i.e., `services.hydra.evaluator.restricted = true`