### PR TITLE
Make Nomad clients use Vault Agent to access Vault API

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -75,6 +75,23 @@
         "type": "github"
       }
     },
+    "lowdown-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1617481909,
+        "narHash": "sha256-SqnfOFuLuVRRNeVJr1yeEPJue/qWoCp5N6o5Kr///p4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "148f9b2f586c41b7e36e73009db43ea68c7a1a4d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "ref": "VERSION_0_8_4",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
     "naersk": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -109,6 +126,25 @@
       "original": {
         "id": "nix",
         "type": "indirect"
+      }
+    },
+    "nix_2": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_2",
+        "nixpkgs": "nixpkgs_6"
+      },
+      "locked": {
+        "lastModified": 1626870457,
+        "narHash": "sha256-QFWvm+4LBZkMS98YxX+oyiVd5IJloz6WJCo1cO61+34=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "3bb8667a1758ad10b5f8621f7e187c38c9c860c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nix",
+        "type": "github"
       }
     },
     "nixpkgs": {
@@ -174,11 +210,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1626163246,
-        "narHash": "sha256-dQWrdoE2JHra/t22wmvLplSGHgoCt1TPhYgA5rQFRqw=",
+        "lastModified": 1626834727,
+        "narHash": "sha256-ToGgus+UImnLNaLgv+xfo/cI3J/NQl2KB5kvyErXays=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b98eb8fd1ee97b512973bf3f836c3da3970cab2",
+        "rev": "63ee5cd99a2e193d5e4c879feb9683ddec23fa03",
         "type": "github"
       },
       "original": {
@@ -204,6 +240,21 @@
       }
     },
     "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1624862269,
+        "narHash": "sha256-JFcsh2+7QtfKdJFoPibLFPLgIW6Ycnv8Bts9a7RYme0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f77036342e2b690c61c97202bf48f2ce13acc022",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1624862269,
         "narHash": "sha256-JFcsh2+7QtfKdJFoPibLFPLgIW6Ycnv8Bts9a7RYme0=",
@@ -257,7 +308,8 @@
         "bitte-cli": "bitte-cli",
         "hydra": "hydra",
         "hydra-provisioner": "hydra-provisioner",
-        "nixpkgs": "nixpkgs_6",
+        "nix": "nix_2",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-terraform": "nixpkgs-terraform",
         "nomad-source": "nomad-source",
         "ops-lib": "ops-lib",

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
       url = "github:input-output-hk/nomad/release-1.1.1";
       flake = false;
     };
+    nix.url = "github:NixOS/nix";
   };
 
   outputs = { self, hydra, hydra-provisioner, nixpkgs, utils, bitte-cli, ... }@inputs:

--- a/modules/consul.nix
+++ b/modules/consul.nix
@@ -425,7 +425,7 @@ in {
         in "!${start-pre}/bin/consul-start-pre";
 
         postScript = let
-          start-pre = pkgs.writeShellScriptBin "consul-start-post" ''
+          start-post = pkgs.writeShellScriptBin "consul-start-post" ''
             set -exuo pipefail
             PATH="${makeBinPath [ pkgs.jq cfg.package pkgs.coreutils ]}"
             set +x
@@ -434,7 +434,7 @@ in {
             set -x
             while ! consul info &>/dev/null; do sleep 3; done
           '';
-        in "!${start-pre}/bin/consul-start-post";
+        in "!${start-post}/bin/consul-start-post";
 
         reloadScript = let
           reload = pkgs.writeShellScriptBin "consul-reload" ''

--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -618,7 +618,7 @@ in {
 
           key_file = mkOption {
             type = nullOr str;
-            default = path;
+            default = null;
             description = ''
               The path to the key file to use for Nomad's TLS communication.
             '';
@@ -1021,7 +1021,7 @@ in {
 
           key_file = mkOption {
             type = nullOr str;
-            default = path;
+            default = null;
             description = ''
               The path to the key file to use for Nomad's TLS communication.
             '';
@@ -1043,6 +1043,8 @@ in {
           };
         };
       };
+
+      apply = filterAttrs (_: v: v != null);
     };
 
     plugin = mkOption {

--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -1096,7 +1096,7 @@ in {
         amazon-ecr-credential-helper
         vault-bin
         jq
-        nixFlakes
+        config.nix.package
         openssh
         git
       ];

--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -1111,7 +1111,7 @@ in {
         start-pre = pkgs.writeShellScript "nomad-start-pre" ''
           PATH="${makeBinPath [ pkgs.coreutils pkgs.busybox ]}"
           set -exuo pipefail
-          ${pkgs.ensureDependencies [ "consul" "vault" ]}
+          # ${pkgs.ensureDependencies [ "consul" "vault" ]}
           cp /etc/ssl/certs/cert-key.pem .
           cp /run/keys/vault-token .
           ${lib.optionalString config.services.vault-agent-core.enable ''

--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -1079,7 +1079,7 @@ in {
     };
 
     systemd.services.nomad = {
-      after = [ "network-online.target" "vault.service" ];
+      after = [ "network-online.target" "vault-agent.service" ];
       wantedBy = [ "multi-user.target" ];
 
       restartTriggers = mapAttrsToList (_: d: d.source)

--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -1079,7 +1079,7 @@ in {
     };
 
     systemd.services.nomad = {
-      after = [ "network-online.target" ];
+      after = [ "network-online.target" "vault.service" ];
       wantedBy = [ "multi-user.target" ];
 
       restartTriggers = mapAttrsToList (_: d: d.source)

--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -6,7 +6,7 @@ let
   inherit (lib)
     mkOption mkEnableOption mkIf mapAttrsToList filterAttrs hasPrefix
     makeBinPath pipe mapAttrs' nameValuePair flip concatMapStrings isList
-    toLower;
+    toLower optionalString;
   inherit (lib.types)
     attrs nullOr attrsOf path package str submodule bool listOf enum port ints;
   inherit (pkgs) snakeCase;
@@ -1136,11 +1136,13 @@ in {
           # TODO: caching this
           set -euo pipefail
 
-          VAULT_TOKEN="$(< vault-token)"
-          export VAULT_TOKEN
+          ${optionalString cfg.server.enabled ''
+            VAULT_TOKEN="$(< vault-token)"
+            export VAULT_TOKEN
 
-          token="$(vault token create -policy ${cfg.tokenPolicy} -period 72h -orphan -field token)"
-          export VAULT_TOKEN="$token"
+            token="$(vault token create -policy ${cfg.tokenPolicy} -period 72h -orphan -field token)"
+            export VAULT_TOKEN="$token"
+          ''}
 
           ${lib.optionalString config.services.vault-agent-core.enable ''
             CONSUL_HTTP_TOKEN_FILE="$PWD/nomad-consul-token"

--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -462,7 +462,7 @@ let
       };
 
       modules = mkOption {
-        type = listOf path;
+        type = listOf (oneOf [ path attrs ]);
         default = [ ];
       };
 
@@ -649,7 +649,7 @@ let
       };
 
       modules = mkOption {
-        type = listOf path;
+        type = listOf (oneOf [ path attrs ]);
         default = [ ];
       };
 

--- a/modules/vault-agent-client.nix
+++ b/modules/vault-agent-client.nix
@@ -34,10 +34,11 @@ let
     #   tls_disable = true;
     # };
 
-    listener.tcp = {
+    listener = [{
+      type = "tcp";
       address = "127.0.0.1:8200";
       tls_disable = true;
-    };
+    }];
 
     auto_auth = {
       method = [{

--- a/modules/vault-agent-client.nix
+++ b/modules/vault-agent-client.nix
@@ -29,16 +29,15 @@ let
     pid_file = "./vault-agent.pid";
     vault.address = "https://vault.${domain}:8200";
 
-    listener.tcp = builtins.fromJSON ''
-        {
-          "address": "127.0.0.1:8200",
-          "cluster_address": "",
-          "tls_cert_file": "/etc/ssl/certs/cert.pem",
-          "tls_client_ca_file": "/etc/ssl/certs/full.pem",
-          "tls_key_file": "/etc/ssl/certs/cert-key.pem",
-          "tls_min_version": "tls12"
-        }
-    '';
+    # listener.unix = {
+    #   address = "/run/vault/socket";
+    #   tls_disable = true;
+    # };
+
+    listener.tcp = {
+      address = "127.0.0.1:8200";
+      tls_disable = true;
+    };
 
     auto_auth = {
       method = [{

--- a/modules/vault-agent-client.nix
+++ b/modules/vault-agent-client.nix
@@ -34,6 +34,9 @@ let
     #   tls_disable = true;
     # };
 
+    # This requires at least one listener
+    # but a listener defined without this would be silently ignored (https://github.com/hashicorp/vault/issues/8953)
+    cache.use_auto_auth_token = true;
     listener = [{
       type = "tcp";
       address = "127.0.0.1:8200";

--- a/modules/vault-agent-client.nix
+++ b/modules/vault-agent-client.nix
@@ -73,9 +73,7 @@ let
             {{ end }}{{ end }}
           '';
 
-          command = writeShellScript "update-cert" ''
-            ${pkgs.systemd}/bin/systemctl restart certs-updated.service || true
-          '';
+          command = "${pkgs.systemd}/bin/systemctl try-reload-or-restart certs-updated.service";
         };
       }
 
@@ -89,9 +87,7 @@ let
             {{ end }}{{ end }}
           '';
 
-          command = writeShellScript "update-cert" ''
-            ${pkgs.systemd}/bin/systemctl restart certs-updated.service || true
-          '';
+          command = "${pkgs.systemd}/bin/systemctl try-reload-or-restart certs-updated.service";
         };
       }
 
@@ -103,9 +99,7 @@ let
             {{ with secret ${pkiSecret} }}{{ .Data.private_key }}{{ end }}
           '';
 
-          command = writeShellScript "update-cert" ''
-            ${pkgs.systemd}/bin/systemctl restart certs-updated.service || true
-          '';
+          command = "${pkgs.systemd}/bin/systemctl try-reload-or-restart certs-updated.service";
         };
       }
 
@@ -129,7 +123,7 @@ let
             }
           '';
 
-          command = "${pkgs.systemd}/bin/systemctl reload consul";
+          command = "${pkgs.systemd}/bin/systemctl try-reload-or-restart consul";
         };
       })
 
@@ -141,7 +135,7 @@ let
             {{ with secret "consul/creds/consul-default" }}{{ .Data.token }}{{ end }}
           '';
 
-          command = "${pkgs.systemd}/bin/systemctl reload consul.service";
+          command = "${pkgs.systemd}/bin/systemctl try-reload-or-restart consul.service";
         };
       })
 
@@ -171,10 +165,7 @@ let
             {{ end }}
           '';
 
-          command = writeShellScript "restart-vault" ''
-            set -xu
-            ${pkgs.systemd}/bin/systemctl restart vault.service || true
-          '';
+          command = "${pkgs.systemd}/bin/systemctl try-reload-or-restart vault.service";
         };
       })
 
@@ -213,12 +204,10 @@ in {
         # minimum
         sleep 10
 
-        systemctl reload consul.service
-
-        # systemctl restart vault.service
+        systemctl try-reload-or-restart consul.service
 
         if curl -s -k https://127.0.0.1:4646/v1/status/leader &> /dev/null; then
-          systemctl restart nomad.service
+          systemctl try-reload-or-restart nomad.service
         else
           systemctl start nomad.service
         fi

--- a/modules/vault-agent-client.nix
+++ b/modules/vault-agent-client.nix
@@ -212,7 +212,7 @@ in {
 
         systemctl reload consul.service
 
-        systemctl restart vault.service
+        # systemctl restart vault.service
 
         if curl -s -k https://127.0.0.1:4646/v1/status/leader &> /dev/null; then
           systemctl restart nomad.service

--- a/modules/vault-agent-client.nix
+++ b/modules/vault-agent-client.nix
@@ -29,6 +29,17 @@ let
     pid_file = "./vault-agent.pid";
     vault.address = "https://vault.${domain}:8200";
 
+    listener.tcp = builtins.fromJSON ''
+        {
+          "address": "127.0.0.1:8200",
+          "cluster_address": "",
+          "tls_cert_file": "/etc/ssl/certs/cert.pem",
+          "tls_client_ca_file": "/etc/ssl/certs/full.pem",
+          "tls_key_file": "/etc/ssl/certs/cert-key.pem",
+          "tls_min_version": "tls12"
+        }
+    '';
+
     auto_auth = {
       method = [{
         type = "aws";

--- a/modules/vault-agent-client.nix
+++ b/modules/vault-agent-client.nix
@@ -229,7 +229,8 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       environment = {
-        inherit (config.environment.variables) AWS_DEFAULT_REGION VAULT_FORMAT;
+        inherit (config.environment.variables) AWS_DEFAULT_REGION;
+        VAULT_FORMAT = "json";
         VAULT_ADDR = "https://vault.${domain}";
         CONSUL_HTTP_ADDR = "127.0.0.1:8500";
         VAULT_SKIP_VERIFY = "true";

--- a/modules/vault-agent-server.nix
+++ b/modules/vault-agent-server.nix
@@ -66,10 +66,10 @@ let
 
         sleep 10
 
-        ${pkgs.systemd}/bin/systemctl restart consul.service
-        ${pkgs.systemd}/bin/systemctl restart nomad.service
-        ${pkgs.systemd}/bin/systemctl restart vault.service
-        ${pkgs.systemd}/bin/systemctl restart ingress.service
+        ${pkgs.systemd}/bin/systemctl try-reload-or-restart consul.service
+        ${pkgs.systemd}/bin/systemctl try-reload-or-restart nomad.service
+        ${pkgs.systemd}/bin/systemctl try-reload-or-restart vault.service
+        ${pkgs.systemd}/bin/systemctl try-reload-or-restart ingress.service
 
         vault write nomad/config/access \
           ca_cert=@/etc/ssl/certs/full.pem \
@@ -83,7 +83,7 @@ let
       (runIf config.services.consul.enable {
         template = {
           destination = "/etc/consul.d/tokens.json";
-          command = "${pkgs.systemd}/bin/systemctl reload consul.service";
+          command = "${pkgs.systemd}/bin/systemctl try-reload-or-restart consul.service";
           contents = if nodeName == "monitoring" then ''
             {
               "acl": {
@@ -116,7 +116,7 @@ let
       (runIf (config.services.consul.enable) {
         template = {
           destination = "/run/keys/consul-default-token";
-          command = "${pkgs.systemd}/bin/systemctl reload consul.service";
+          command = "${pkgs.systemd}/bin/systemctl try-reload-or-restart consul.service";
           contents = ''
             {{ with secret "consul/creds/consul-server-default" }}{{ .Data.token }}{{ end }}
           '';
@@ -126,7 +126,7 @@ let
       # TODO: remove duplication
       (runIf config.services.nomad.enable {
         template = {
-          command = "${pkgs.systemd}/bin/systemctl restart nomad.service";
+          command = "${pkgs.systemd}/bin/systemctl try-reload-or-restart nomad.service";
           destination = "/etc/nomad.d/consul-token.json";
           contents = ''
             {
@@ -140,7 +140,7 @@ let
 
       (runIf config.services.nomad.enable {
         template = {
-          command = "${pkgs.systemd}/bin/systemctl restart nomad.service";
+          command = "${pkgs.systemd}/bin/systemctl try-reload-or-restart nomad.service";
           destination = "/run/keys/nomad-consul-token";
           contents = ''
             {{- with secret "consul/creds/nomad-server" }}{{ .Data.token }}{{ end -}}
@@ -151,7 +151,7 @@ let
       (runIf config.services.nomad-autoscaler.enable {
         template = {
           command =
-            "${pkgs.systemd}/bin/systemctl restart nomad-autoscaler.service";
+            "${pkgs.systemd}/bin/systemctl try-reload-or-restart nomad-autoscaler.service";
           destination = "/run/keys/nomad-autoscaler-token";
           contents = ''
             {{- with secret "nomad/creds/nomad-autoscaler" }}{{ .Data.secret_id }}{{ end -}}

--- a/modules/vault.nix
+++ b/modules/vault.nix
@@ -348,11 +348,17 @@ in {
           cp /etc/ssl/certs/cert-key.pem .
           chown --reference . --recursive .
         '';
+
+        postScript = pkgs.writeShellScriptBin "vault-start-post" ''
+          export PATH="${makeBinPath [ pkgs.coreutils pkgs.vault-bin ]}"
+          while ! vault status; do sleep 3; done
+        '';
       in {
         ExecStartPre = "!${preScript}/bin/vault-start-pre";
         ExecStart =
           "@${pkgs.vault-bin}/bin/vault vault server -config /etc/${cfg.configDir}";
 
+        ExecStartPost = "!${postScript}/bin/vault-start-post";
         KillSignal = "SIGINT";
 
         StateDirectory = baseNameOf cfg.storagePath;

--- a/overlay.nix
+++ b/overlay.nix
@@ -4,9 +4,9 @@ let
   inherit (builtins) fromJSON toJSON trace mapAttrs genList foldl';
   inherit (nixpkgs) lib;
 in final: prev: {
-  # Without this the `nixos-rebuild` included in `nixpkgs` would
-  # try to use Nix 2.3 with `--experimental-features` and thereby croak and die.
-  nix = final.nixUnstable;
+  nix = inputs.nix.packages.x86_64-linux.nix;
+  nixFlakes = final.nix;
+  nixUnstable = final.nix;
 
   hydra-unstable = prev.hydra-unstable.overrideAttrs (oldAttrs: {
     patches = (oldAttrs.patches or [ ]) ++ [

--- a/pkgs/bitte-shell.nix
+++ b/pkgs/bitte-shell.nix
@@ -1,23 +1,6 @@
-{ bitte
-, lib
-, writeText
-, mkShell
-, nixos-rebuild
-, terraform-with-plugins
-, scaler-guard
-, sops
-, vault
-, openssl
-, cfssl
-, nixfmt
-, awscli
-, nomad
-, consul
-, consul-template
-, python38Packages
-, direnv
-, nixFlakes
-, jq }:
+{ bitte, lib, writeText, mkShell, nixos-rebuild, terraform-with-plugins
+, scaler-guard, sops, vault, openssl, cfssl, nixfmt, awscli, nomad, consul
+, consul-template, python38Packages, direnv, jq }:
 
 { cluster
 , caCert ? null
@@ -65,7 +48,6 @@ in mkShell ({
     consul-template
     python38Packages.pyhcl
     direnv
-    nixFlakes
     jq
   ] ++ extraPackages;
 } // (lib.optionalAttrs (caCert != null) {

--- a/profiles/client.nix
+++ b/profiles/client.nix
@@ -15,6 +15,7 @@
   services = {
     amazon-ssm-agent.enable = true;
     vault-agent-client.enable = true;
+    vault.enable = lib.mkForce false;
     nomad.enable = true;
     telegraf.extraConfig.global_tags.role = "consul-client";
     zfs-client-options.enable = true;

--- a/profiles/nomad/client.nix
+++ b/profiles/nomad/client.nix
@@ -19,7 +19,7 @@
 
     plugin.raw_exec.enabled = false;
 
-    vault.address = "https://127.0.0.1:8200";
+    vault.address = "http://127.0.0.1:8200";
   };
 
   system.extraDependencies = [ pkgs.pkgsStatic.busybox ];

--- a/profiles/nomad/default.nix
+++ b/profiles/nomad/default.nix
@@ -40,9 +40,9 @@ in {
 
     vault = {
       enabled = true;
-      ca_file = full;
-      cert_file = cert;
-      key_file = key;
+      # ca_file = full;
+      # cert_file = cert;
+      # key_file = key;
       create_from_role = "nomad-cluster";
     };
 


### PR DESCRIPTION
Currently:
- Nomad clients have both Vault server and agent running.
- Vault Server is bound to `0.0.0.0` and as such must be configured with TLS, which adds non-negligible complexity as those certificates originate from Vault itself.
- Vault Agent is only used to render templates
- Nomad Agent is configured to access Vault at `127.0.0.1`, via https. If I understand the docs correctly, that is not only superfluous but also suboptimal: a vault server who's not the leader would merely redirect requests to the leader. That doesn't really gain us much. On the other hand, a Vault Agent can act as a caching proxy to the Vault API, which gains us some fault tolerance.

Changes introduced:
- Disable Vault server on clients
- Enable Vault Agent API caching and configure a no-TLS listener bound to `127.0.0.1` (effectively delegating TLS termination to the agent)
- Configure Nomad Agent to talk to Vault Agent via `http` rather than `https`
- Skip the creation of a vault token in the `nomad` systemd service unless it's a server. The docs stress that clients do not require a Vault token (https://www.nomadproject.io/docs/integrations/vault-integration#vault-configuration)
- Fix infinite recursion caused by a couple of options defaulting to `lib.types.path` which seems like an obvious mistake/typo.
