### PR TITLE
remove nix from devShell

### DIFF
--- a/pkgs/bitte-shell.nix
+++ b/pkgs/bitte-shell.nix
@@ -1,6 +1,6 @@
 { bitte, lib, writeText, mkShell, nixos-rebuild, terraform-with-plugins
 , scaler-guard, sops, vault, openssl, cfssl, nixfmt, awscli, nomad, consul
-, consul-template, python38Packages, direnv, nixFlakes, jq }:
+, consul-template, python38Packages, direnv, jq }:
 
 { cluster, caCert ? null, domain, extraEnv ? { }, extraPackages ? [ ], region
 , profile, namespace ? cluster, nixConfig ? null }:
@@ -41,7 +41,6 @@ in mkShell ({
     consul-template
     python38Packages.pyhcl
     direnv
-    nixFlakes
     jq
   ] ++ extraPackages;
 } // (lib.optionalAttrs (caCert != null) {


### PR DESCRIPTION
I didn't want to just push this, since I'm not sure how some of you feel about it, but I dislike having my custom patched nix overriden by the devShell. It's very confusing and annoying. If you agree, then please merge this.