### PR TITLE
Dns mods, Hashicorp Stack updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -213,16 +213,16 @@
     "nomad-source": {
       "flake": false,
       "locked": {
-        "lastModified": 1623434122,
-        "narHash": "sha256-3cPp8STtTKMHtA2+rWqAjHVevAnUorRtZFWRnmaLLJc=",
+        "lastModified": 1627692000,
+        "narHash": "sha256-oc+d4kI4YNwUVPxV1K2Ggq4+fb+QJRzFzy/GSagJ+wg=",
         "owner": "input-output-hk",
         "repo": "nomad",
-        "rev": "1e35d887c0de086d344d7f9514eb0f63c3c68199",
+        "rev": "23555d8cf50eec427c2f910203c19570bcd56545",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "release-1.1.1",
+        "ref": "release-1.1.3",
         "repo": "nomad",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
 
       packages = { bitte, cfssl, consul, cue, glusterfs, grafana-loki, haproxy
         , haproxy-auth-request, haproxy-cors, nixFlakes, nomad, nomad-autoscaler
-        , oauth2_proxy, sops, ssm-agent, terraform-with-plugins, vault-backend
+        , oauth2-proxy, sops, ssm-agent, terraform-with-plugins, vault-backend
         , vault-bin, ci-env }@pkgs:
         pkgs;
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       flake = false;
     };
     nomad-source = {
-      url = "github:input-output-hk/nomad/release-1.1.1";
+      url = "github:input-output-hk/nomad/release-1.1.2";
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       flake = false;
     };
     nomad-source = {
-      url = "github:input-output-hk/nomad/release-1.1.2";
+      url = "github:input-output-hk/nomad/release-1.1.3";
       flake = false;
     };
   };

--- a/modules/terraform/network.nix
+++ b/modules/terraform/network.nix
@@ -17,20 +17,20 @@ let
     lib.unique (lib.sort (a: b: a < b) (mapVpcsToList (vpc: vpc.region)));
 
   # The following definitions prepare a mesh of unique peeringPairs,
-  # each with a connector and acceptor.  The following is an example of
+  # each with a connector and accepter.  The following is an example of
   # a vpcRegions input list and a peeringPairs output list:
   #
   # vpcRegions = [ "us-east-2" "eu-central-1" "eu-west-1" ]
   # peeringPairs = [
-  #   { connector = "eu-central-1"; acceptor = "eu-west-1"; }
-  #   { connector = "eu-central-1"; acceptor = "us-east-2"; }
-  #   { connector = "eu-west-1";    acceptor = "us-east-2"; }
+  #   { connector = "eu-central-1"; accepter = "eu-west-1"; }
+  #   { connector = "eu-central-1"; accepter = "us-east-2"; }
+  #   { connector = "eu-west-1";    accepter = "us-east-2"; }
   # ]
 
   regionPeeringPairs = vpcs: connector: index:
-    map (acceptor: {
+    map (accepter: {
       connector = connector;
-      acceptor = acceptor;
+      accepter = accepter;
     }) (lib.drop (index + 1) vpcs);
   peeringPairs = lib.flatten
     (lib.imap0 (i: connector: regionPeeringPairs vpcRegions connector i)
@@ -119,14 +119,14 @@ in {
                   innerVpc.region
                 else
                   vpc.region;
-                acceptor = if innerVpc.region > vpc.region then
+                accepter = if innerVpc.region > vpc.region then
                   innerVpc.region
                 else
                   vpc.region;
               in nullRoute // {
                 cidr_block = innerVpc.cidr;
                 vpc_peering_connection_id = id
-                  "aws_vpc_peering_connection.${connector}-connect-${acceptor}";
+                  "aws_vpc_peering_connection.${connector}-connect-${accepter}";
               }));
 
         tags = tags // {
@@ -175,17 +175,17 @@ in {
           Region = vpc.region;
         };
       }) // (mapVpcPeers (link:
-        lib.nameValuePair "${link.connector}-connect-${link.acceptor}" {
+        lib.nameValuePair "${link.connector}-connect-${link.accepter}" {
           provider = awsProviderFor link.connector;
           vpc_id = id "aws_vpc.${link.connector}";
-          peer_vpc_id = id "aws_vpc.${link.acceptor}";
+          peer_vpc_id = id "aws_vpc.${link.accepter}";
           peer_owner_id = var "data.aws_caller_identity.core.account_id";
-          peer_region = link.acceptor;
+          peer_region = link.accepter;
           auto_accept = false;
           lifecycle = [{ create_before_destroy = true; }];
 
           tags = tags // {
-            Name = "${link.connector}-connect-${link.acceptor}";
+            Name = "${link.connector}-connect-${link.accepter}";
             Region = link.connector;
           };
         }));
@@ -204,16 +204,63 @@ in {
           Region = vpc.region;
         };
       }) // (mapVpcPeers (link:
-        lib.nameValuePair "${link.acceptor}-accept-${link.connector}" {
-          provider = awsProviderFor link.acceptor;
+        lib.nameValuePair "${link.accepter}-accept-${link.connector}" {
+          provider = awsProviderFor link.accepter;
           vpc_peering_connection_id = id
-            "aws_vpc_peering_connection.${link.connector}-connect-${link.acceptor}";
+            "aws_vpc_peering_connection.${link.connector}-connect-${link.accepter}";
           auto_accept = true;
           lifecycle = [{ create_before_destroy = true; }];
           tags = tags // {
-            Name = "${link.acceptor}-accept-${link.connector}";
-            Region = link.acceptor;
+            Name = "${link.accepter}-accept-${link.connector}";
+            Region = link.accepter;
           };
         }));
+
+    # Set up cross vpc DNS resolution from each autoscaling region to the core region (1st and 2nd let block defns)
+    # Then add on the mesh cross vpc DNS resolution (3rd and 4th let block defns)
+    resource.aws_vpc_peering_connection_options = let
+      accepterCorePeeringOptions = mapVpcs (vpc:
+        lib.nameValuePair "${vpc.region}-accepter" {
+          provider = awsProviderFor config.cluster.region;
+          vpc_peering_connection_id =
+            id "aws_vpc_peering_connection_accepter.${vpc.region}";
+
+          accepter = { allow_remote_vpc_dns_resolution = true; };
+        });
+
+      requesterCorePeeringOptions = mapVpcs (vpc:
+        lib.nameValuePair vpc.region {
+          provider = awsProviderFor vpc.region;
+          vpc_peering_connection_id =
+            id "aws_vpc_peering_connection.${vpc.region}";
+
+          requester = { allow_remote_vpc_dns_resolution = true; };
+        });
+
+      accepterMeshPeeringOptions = mapVpcPeers (link:
+        lib.nameValuePair "${link.accepter}-accept-${link.connector}" {
+          provider = awsProviderFor link.accepter;
+          vpc_peering_connection_id = id
+            "aws_vpc_peering_connection_accepter.${link.accepter}-accept-${link.connector}";
+
+          accepter = { allow_remote_vpc_dns_resolution = true; };
+        });
+
+      requesterMeshPeeringOptions = mapVpcPeers (link:
+        lib.nameValuePair "${link.connector}-connect-${link.accepter}" {
+          provider = awsProviderFor link.connector;
+          vpc_peering_connection_id = id
+            "aws_vpc_peering_connection.${link.connector}-connect-${link.accepter}";
+
+          requester = { allow_remote_vpc_dns_resolution = true; };
+        });
+
+      recursiveMerge = lib.foldr lib.recursiveUpdate { };
+    in recursiveMerge [
+      accepterCorePeeringOptions
+      accepterMeshPeeringOptions
+      requesterCorePeeringOptions
+      requesterMeshPeeringOptions
+    ];
   };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -104,7 +104,8 @@ in final: prev: {
 
   vault-backend = final.callPackage ./pkgs/vault-backend.nix { };
 
-  oauth2_proxy = final.callPackage ./pkgs/oauth2_proxy.nix { };
+  oauth2-proxy = final.callPackage ./pkgs/oauth2_proxy.nix { };
+
 
   filebeat = final.callPackage ./pkgs/filebeat.nix { };
 

--- a/pkgs/bitte-shell.nix
+++ b/pkgs/bitte-shell.nix
@@ -6,7 +6,7 @@
 , terraform-with-plugins
 , scaler-guard
 , sops
-, vault
+, vault-bin
 , openssl
 , cfssl
 , nixfmt
@@ -58,7 +58,7 @@ mkShell ({
     terraform-with-plugins
     scaler-guard
     sops
-    vault
+    vault-bin
     openssl
     cfssl
     nixfmt

--- a/pkgs/consul/default.nix
+++ b/pkgs/consul/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "consul";
-  version = "1.9.6";
+  version = "1.10.1";
   rev = "v${version}";
 
   # Note: Currently only release tags are supported, because they have the Consul UI
@@ -17,7 +17,7 @@ buildGoModule rec {
     owner = "hashicorp";
     repo = pname;
     inherit rev;
-    sha256 = "sha256-SuG/Q5Tjet4etd4Qy5NBQLYEe2QO0K8QHKmgxYMl09U=";
+    sha256 = "sha256-oap0pXqtIbT9wMfD/RuJ2tTRynSvfzsgL8TyY4nj3sM=";
   };
 
   patches = [ ./script-check.patch ];
@@ -28,7 +28,7 @@ buildGoModule rec {
   # has a split module structure in one repo
   subPackages = [ "." "connect/certgen" ];
 
-  vendorSha256 = "sha256-ix1GMv0n7NrcSqqd5widTa+K3bg8lA43nZVGI8M0Cb4=";
+  vendorSha256 = "sha256-ZhHjMLLTN4PP60n2ejU+C3xt3PGGURVC+aq3GgLl7A4=";
   deleteVendor = true;
 
   preBuild = ''

--- a/pkgs/nomad.nix
+++ b/pkgs/nomad.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   pname = "nomad";
-  version = "1.1.1";
+  version = "1.1.2";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/nomad";

--- a/pkgs/nomad.nix
+++ b/pkgs/nomad.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, buildGoPackage, nomad-source }:
+{ lib, stdenv, buildGoModule, nomad-source }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "nomad";
-  version = "1.1.2";
-  rev = "v${version}";
+  version = "1.1.3";
 
-  goPackagePath = "github.com/hashicorp/nomad";
   subPackages = [ "." ];
 
   src = nomad-source;
+
+  vendorSha256 = "sha256-2aN1yf5+UHhCgbU4uyYtoeIXs51tLp55yY6KJE5+5Cs=";
 
   # ui:
   #  Nomad release commits include the compiled version of the UI, but the file

--- a/pkgs/oauth2_proxy.nix
+++ b/pkgs/oauth2_proxy.nix
@@ -2,16 +2,19 @@
 
 buildGoModule rec {
   pname = "oauth2-proxy";
-  version = "7.0.1";
+  version = "7.1.3";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "oauth2-proxy";
-    sha256 = "sha256-VmVVEkOLY6NjjxGx2sZkj3+LW/aTAe0YINZ9HFy38MU=";
-    rev = "76269a13b72afa1e46be799e2d835cfab406c1cf";
+    sha256 = "sha256-zFXDv4in0zR7QdO7jg8ESKPBXEU+9bt/Desl7M6iKDg=";
+    rev = "88122f641de3f7a5cc25a2bae121b07e04b8fe4b";
   };
 
-  vendorSha256 = "sha256-d7gX/fFGTGHyO6buicyvBARc1zhy5BQWRMwLV9w3Z2s=";
+  vendorSha256 = "sha256-DNcXHafuUIIYDI7uTcyCQbDVpkGWV+76NZFVK/HqkUM=";
+
+  # This package will try to bind IP:Ports during tests and fail unless sandboxing is disabled
+  doCheck = false;
 
   # Taken from https://github.com/oauth2-proxy/oauth2-proxy/blob/master/Makefile
   buildFlagsArray = ("-ldflags=-X main.VERSION=${version}");

--- a/pkgs/vault-bin.nix
+++ b/pkgs/vault-bin.nix
@@ -1,21 +1,21 @@
 { stdenv, lib, fetchurl, unzip, makeWrapper, gawk, glibc }:
 
 let
-  version = "1.7.2";
+  version = "1.7.3";
 
   sources = let base = "https://releases.hashicorp.com/vault/${version}";
   in {
     x86_64-linux = fetchurl {
       url = "${base}/vault_${version}_linux_amd64.zip";
-      sha256 = "sha256-Xua7gRm1XCfNOGTJghd3FKCko4E5J8yv2yYueOS7Z7w=";
+      sha256 = "sha256-hFMTKpO3VcCondSy8amb1K8G+BZ7gZF/EXCAg5Ax4D8=";
     };
     x86_64-darwin = fetchurl {
       url = "${base}/vault_${version}_darwin_amd64.zip";
-      sha256 = "sha256-fTfhLMuUl6nkA9Vi2Dey6nuZ2+kZ5pVq3h4uQQpU9XM=";
+      sha256 = "sha256-Ns8a48CwEfVNek37l+Dxr9jcPeQaGfM4tU2rJWEzhWs=";
     };
     aarch64-linux = fetchurl {
       url = "${base}/vault_${version}_linux_arm64.zip";
-      sha256 = "sha256-K7nUmyU4k/+iFJ7oXOLyvHI2CiwUrId1FV80xXI0RTM=";
+      sha256 = "sha256-IwkvYNi8lrXEDOxx/skz524Ur7lSxc0bjVg1RZABXDA=";
     };
   };
 

--- a/pkgs/vault-bin.nix
+++ b/pkgs/vault-bin.nix
@@ -1,21 +1,21 @@
 { stdenv, lib, fetchurl, unzip, makeWrapper, gawk, glibc }:
 
 let
-  version = "1.7.3";
+  version = "1.8.0";
 
   sources = let base = "https://releases.hashicorp.com/vault/${version}";
   in {
     x86_64-linux = fetchurl {
       url = "${base}/vault_${version}_linux_amd64.zip";
-      sha256 = "sha256-hFMTKpO3VcCondSy8amb1K8G+BZ7gZF/EXCAg5Ax4D8=";
+      sha256 = "sha256-H+kPDE8xuu2lgENf4t+vCb+Tni+ChkB8K5ZEgIY3Jyo=";
     };
     x86_64-darwin = fetchurl {
       url = "${base}/vault_${version}_darwin_amd64.zip";
-      sha256 = "sha256-Ns8a48CwEfVNek37l+Dxr9jcPeQaGfM4tU2rJWEzhWs=";
+      sha256 = "sha256-ubG4DLoWWm2ujFu/YgfxyU9mnuZP3sXCwh7g+kwGFH8=";
     };
     aarch64-linux = fetchurl {
       url = "${base}/vault_${version}_linux_arm64.zip";
-      sha256 = "sha256-IwkvYNi8lrXEDOxx/skz524Ur7lSxc0bjVg1RZABXDA=";
+      sha256 = "sha256-rLo+al+F4tNBxnLHETDDZ4NcxE92/bJWZzIibNV8U6o=";
     };
   };
 

--- a/profiles/consul/default.nix
+++ b/profiles/consul/default.nix
@@ -77,7 +77,10 @@ in {
   services.dnsmasq = {
     enable = true;
     extraConfig = ''
-      # Ensure docker0 is also bound on client machines when it may not exist during dnsmasq startup
+      # Ensure docker0 is also bound on client machines when it may not exist during dnsmasq startup:
+      # - This ensures nomad docker driver jobs have dnsmasq access
+      # - This enables nomad exec driver bridge mode jobs to use the docker bridge for dnsmasq access
+      #   when explicitly defined as a nomad network dns server ip
       bind-dynamic
 
       # Redirect consul and ec2 internal specific queries to their respective upstream DNS servers

--- a/profiles/consul/default.nix
+++ b/profiles/consul/default.nix
@@ -77,14 +77,24 @@ in {
   services.dnsmasq = {
     enable = true;
     extraConfig = ''
+      # Ensure docker0 is also bound on client machines when it may not exist during dnsmasq startup
+      bind-dynamic
+
+      # Redirect consul and ec2 internal specific queries to their respective upstream DNS servers
       server=/consul/127.0.0.1#8600
       server=/internal/169.254.169.253#53
+
+      # Configure reverse in-addr.arpa DNS lookups to consul for ASGs and core datacenter default address ranges
       rev-server=10.0.0.0/8,127.0.0.1#8600
-      rev-server=127.0.0.1/8,127.0.0.1#8600
-      local-service
+      rev-server=172.16.0.0/16,127.0.0.1#8600
+
+      # Define upstream DNS servers
       server=169.254.169.253
       server=8.8.8.8
+
+      # Set cache and security
       cache-size=65536
+      local-service
     '';
   };
 

--- a/schemas/nomad/types.cue
+++ b/schemas/nomad/types.cue
@@ -123,7 +123,7 @@ import (
 		Affinities: [...Affinity]
 		Constraints: [...Constraint]
 		Spreads: [...Spread]
-		Count: uint & >0
+		Count: int & >0 | *1
 		Meta: [string]: string
 		Name:          string
 		RestartPolicy: *null | #json.RestartPolicy
@@ -145,6 +145,10 @@ import (
 		Vault:                     *null | #json.Vault
 	}
 
+	Dns: {
+		servers: *null | [...string]
+	}
+
 	Port: {
 		Label:       string
 		Value:       uint | *null // used for static ports
@@ -157,7 +161,7 @@ import (
 		Device:        string | *""
 		CIDR:          string | *""
 		IP:            string | *""
-		DNS:           null
+		DNS:           *null | #json.Dns
 		ReservedPorts: *null | [...#json.Port]
 		DynamicPorts:  *null | [...#json.Port]
 		MBits:         null
@@ -285,9 +289,10 @@ import (
 	}
 }
 
-#duration:    =~"^[1-9]\\d*[hms]$"
-#gitRevision: =~"^[a-f0-9]{40}$"
-#flake:       =~"^(github|git\\+ssh|git):[0-9a-zA-Z_-]+/[0-9a-zA-Z_-]+"
+#dockerUrlPath: =~"^[0-9a-zA-Z-.]+/[0-9a-zA-Z-]+:[0-9a-zA-Z-]+$"
+#duration:      =~"^[1-9]\\d*[hms]$"
+#gitRevision:   =~"^[a-f0-9]{40}$"
+#flake:         =~"^(github|git\\+ssh|git):[0-9a-zA-Z_-]+/[0-9a-zA-Z_-]+"
 
 // The #toJson block is evaluated from deploy.cue during rendering of the namespace jobs.
 // #job and #jobName are passed to #toJson during this evaluation.
@@ -434,6 +439,7 @@ import (
 		if tg.network != null {
 			Networks: [{
 				Mode: tg.network.mode
+				DNS:  tg.network.dns
 				ReservedPorts: [
 					for nName, nValue in tg.network.port if nValue.static != null {
 						Label:       nName
@@ -780,9 +786,14 @@ import (
 		image:   string
 		command: *null | string
 		args: [...string]
-		ports: [...string]
+		cap_add:     *null | [...string]
+		entrypoint:  *null | [...string]
+		interactive: *null | bool
+		ipc_mode:    *null | string
 		labels: [...#label]
 		logging: dockerConfigLogging
+		ports: [...string]
+		sysctl: *null | [ {[string]: string}]
 	}
 
 	dockerConfigLogging: {


### PR DESCRIPTION
Dns improvements and fixes:
* Dns fixup of docker driver and exec bridge jobs in dnsmasq config
* Adds dnsmasq bind-dynamic and in-addr.arpa updates
* Adds cross VPC bitte AWS DNS resolution (unblocks cross VPC query dependent sw, ex: rabbitmq HA)

Hashicorp stack updates:
* consul 1.9.6 -> 1.10.1
* vault 1.7.2 -> 1.8.0; use also in bitteShell
* nomad 1.1.1 -> 1.1.3 (switch from buildGoPackage -> buildGoModule)

Other updates:
* Adds dns, docker type updates to cue schema
* oauth2-proxy 7.0.1 -> 7.1.3
* Nix flakes driver updates (multiple flakes supported)

Application:
* Cross vpc dns query requires `bitte tf network plan`, `bitte tf network apply`
* Dns fixes for docker and exec driver require bitte rebuild of auto-scaler nodes
* Hashicorp stack binary updates are per Hashicorp upgrade procedure