### PR TITLE
Create aggregate job for commit status reporting

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,15 @@
         , vault-bin, ci-env }@pkgs:
         pkgs;
 
-      hydraJobs = packages;
+      hydraJobs = { bitte, cfssl, consul, cue, glusterfs, grafana-loki, haproxy
+        , haproxy-auth-request, haproxy-cors, nixFlakes, nomad, nomad-autoscaler
+        , oauth2-proxy, sops, ssm-agent, terraform-with-plugins, vault-backend
+        , vault-bin, ci-env, mkRequired }@pkgs: let
+        constituents = builtins.removeAttrs pkgs [ "mkRequired" ];
+      in
+        constituents // {
+        	required = mkRequired constituents;
+        };
 
       apps = { bitte }: {
         bitte = utils.lib.mkApp { drv = bitte; };

--- a/lib/mk-hashi-stack.nix
+++ b/lib/mk-hashi-stack.nix
@@ -149,11 +149,7 @@ in lib.makeScope pkgs.newScope (self:
         lib.mapAttrs (_: { config, ... }: config.system.build.toplevel)
         self.nixosConfigurations;
     in nixosConfigurations // {
-      required = pkgs.releaseTools.aggregate {
-        name = "nixosConfigurations";
-        constituents = (builtins.attrValues nixosConfigurations) ++ [ build-version ];
-        meta.description = "All NixOS Configurations";
-      };
+      required = mkRequired nixosConfigurations;
     };
   })
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,7 +1,7 @@
 inputs:
 let
   inherit (inputs) nixpkgs ops-lib nixpkgs-terraform;
-  inherit (builtins) fromJSON toJSON trace mapAttrs genList foldl';
+  inherit (builtins) attrValues fromJSON toJSON trace mapAttrs genList foldl';
   inherit (nixpkgs) lib;
 in final: prev: {
   # Without this the `nixos-rebuild` included in `nixpkgs` would
@@ -106,6 +106,16 @@ in final: prev: {
 
   oauth2-proxy = final.callPackage ./pkgs/oauth2_proxy.nix { };
 
+  mkRequired = constituents:
+    let
+      build-version = final.writeText "version.json" (toJSON {
+        inherit (inputs.self) lastModified lastModifiedDate narHash outPath shortRev rev;
+      });
+    in final.releaseTools.aggregate {
+        name = "required";
+        constituents = (attrValues constituents) ++ [ build-version ];
+        meta.description = "All required derivations";
+      };
 
   filebeat = final.callPackage ./pkgs/filebeat.nix { };
 


### PR DESCRIPTION
This factors out the logic used in `mkHashistack` to create the `required` hydra job so that it can be used in bitte's own `hydraJobs` as well.