### PR TITLE
Connect related consul patches and config, script improvements

### DIFF
--- a/modules/consul.nix
+++ b/modules/consul.nix
@@ -401,10 +401,6 @@ in {
           enableScriptChecks;
       });
 
-    environment.etc."${cfg.configDir}/extra-config.json".source =
-      mkIf (cfg.extraConfig != null)
-      (pkgs.toPrettyJSON "config" (sanitize cfg.extraConfig));
-
     systemd.services.consul = {
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];

--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -522,6 +522,17 @@ in {
             depend on this value being set.
           '';
 
+          heartbeat_grace = mkOption {
+            type = str;
+            default = "30s";
+            description = ''
+              Specifies the additional time given as a grace period beyond the
+              heartbeat TTL of nodes to account for network and processing delays as
+              well as clock skew. This is specified using a label suffix like
+              "30s" or "1h".
+            '';
+          };
+
           server_join = mkOption {
             type = serverJoinType;
             default = { };
@@ -1101,10 +1112,7 @@ in {
         git
       ];
 
-      environment = mkIf config.services.consul.enable {
-        CONSUL_HTTP_ADDR = "http://127.0.0.1:8500";
-        # certificates get rotated often, we got no way to update them while
-        # the jobs are running...
+      environment = {
         VAULT_SKIP_VERIFY = "true";
         HOME = "/var/lib/nomad";
       };

--- a/pkgs/consul/consul-issue-9639.patch
+++ b/pkgs/consul/consul-issue-9639.patch
@@ -1,0 +1,16 @@
+diff --git i/agent/xds/listeners.go w/agent/xds/listeners.go
+index 4e528cf73..9c33a2079 100644
+--- i/agent/xds/listeners.go
++++ w/agent/xds/listeners.go
+@@ -1598,6 +1598,11 @@ func makeHTTPFilter(opts listenerFilterOpts) (*envoy_listener_v3.Filter, error)
+ 			// sampled.
+ 			RandomSampling: &envoy_type_v3.Percent{Value: 0.0},
+ 		},
++		UpgradeConfigs: []*envoy_http_v3.HttpConnectionManager_UpgradeConfig{
++			{
++				UpgradeType: "websocket",
++			},
++		},
+ 	}
+ 
+ 	if opts.useRDS {

--- a/pkgs/consul/default.nix
+++ b/pkgs/consul/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, fetchurl, nixosTests }:
+{ pkgs, lib, buildGoModule, fetchFromGitHub, fetchurl, nixosTests }:
 
 buildGoModule rec {
   pname = "consul";
@@ -20,7 +20,15 @@ buildGoModule rec {
     sha256 = "sha256-oap0pXqtIbT9wMfD/RuJ2tTRynSvfzsgL8TyY4nj3sM=";
   };
 
-  patches = [ ./script-check.patch ];
+  patches = [
+    ./script-check.patch
+    # Fix no envoy upstream listener issue specific to Consul v1.10.1
+    (if version == "1.10.1" then (pkgs.fetchpatch {
+      name = "consul-issue-10714-patch";
+      url = "https://github.com/hashicorp/consul/commit/3e2ec34409babda7f625889f3620c9d3810521fc.patch";
+      sha256 = "sha256-H+LhhISrM829yn93SfIsJzD0JgTPfPoBIzfZ30TLIek=";
+    }) else null)
+  ];
 
   passthru.tests.consul = nixosTests.consul;
 

--- a/pkgs/consul/default.nix
+++ b/pkgs/consul/default.nix
@@ -22,6 +22,8 @@ buildGoModule rec {
 
   patches = [
     ./script-check.patch
+    # Fix no http protocol upgrades through envoy
+    ./consul-issue-9639.patch
     # Fix no envoy upstream listener issue specific to Consul v1.10.1
     (if version == "1.10.1" then (pkgs.fetchpatch {
       name = "consul-issue-10714-patch";

--- a/profiles/consul/default.nix
+++ b/profiles/consul/default.nix
@@ -61,17 +61,6 @@ in {
       https = 8501;
       http = 8500;
     };
-
-    extraConfig = {
-      configEntries = [{
-        bootstrap = [{
-          kind = "proxy-defaults";
-          name = "global";
-          config = [{ protocol = "http"; }];
-          meshGateway = [{ mode = "local"; }];
-        }];
-      }];
-    };
   };
 
   services.dnsmasq = {

--- a/profiles/nomad/client.nix
+++ b/profiles/nomad/client.nix
@@ -22,6 +22,14 @@
     vault.address = "http://127.0.0.1:8200";
   };
 
+  systemd.services.nomad.environment = {
+    CONSUL_HTTP_ADDR = "https://127.0.0.1:8501";
+    CONSUL_HTTP_SSL = "true";
+    CONSUL_CACERT = config.services.consul.caFile;
+    CONSUL_CLIENT_CERT = config.services.consul.certFile;
+    CONSUL_CLIENT_KEY = config.services.consul.keyFile;
+  };
+
   system.extraDependencies = [ pkgs.pkgsStatic.busybox ];
 
   users.extraUsers.nobody.isSystemUser = true;

--- a/profiles/nomad/default.nix
+++ b/profiles/nomad/default.nix
@@ -47,9 +47,12 @@ in {
     };
 
     consul = {
-      address = "127.0.0.1:${toString config.services.consul.ports.http}";
-      ssl = false;
+      address = "127.0.0.1:${toString config.services.consul.ports.https}";
+      ssl = true;
       allow_unauthenticated = true;
+      ca_file = full;
+      cert_file = cert;
+      key_file = key;
     };
 
     telemetry = {

--- a/profiles/nomad/server.nix
+++ b/profiles/nomad/server.nix
@@ -29,4 +29,8 @@ in {
       };
     };
   };
+
+  systemd.services.nomad.environment = {
+    CONSUL_HTTP_ADDR = "http://127.0.0.1:8500";
+  };
 }


### PR DESCRIPTION
* Patches consul envoy http protocol upgrade issue [9639](https://github.com/hashicorp/consul/pull/9639)
* Patches consul 1.10.1 for connect listener issue [10714](https://github.com/hashicorp/consul/pull/10714)
* Increase nomad heartbeat grace from 10s to 30s to reduce Nomad job chaos during client rebuilds
* Configs nomad clients to use consul TLS for connect (eliminates passing TLS certs to envoy sidecar)
* Clean up vault-agent-client and misc consul extraConfig