### PR TITLE
Don't import modules, keep as paths

### DIFF
--- a/lib/make-modules.nix
+++ b/lib/make-modules.nix
@@ -14,7 +14,7 @@ let
       expanded = mapAttrs (name: type:
         if (type == "regular") && (lib.strings.hasSuffix ".nix" name) then [
           (join prefix name)
-          (import (d + "/${name}"))
+          (d + "/${name}")
         ] else if type == "directory" then [
           (join prefix name)
           (convert (join prefix name) (d + "/${name}"))


### PR DESCRIPTION
Was having issues rebuilding a cluster

```
error: A definition for option `cluster.autoscalingGroups.client-us-east-2-c5-4xlarge.modules.[definition 1-entry 1]' is not of type `path or attribute set'. Definition values:
       - In `/nix/store/sz6yw0k00rhm689n62agi865gxydh3kj-source/clusters/<cluster>/testnet/default.nix': <function, args: {config, lib, pkgs, self}>

       … while evaluating the attribute 'value'
       ```