### PR TITLE
cleanup(vault-policies): `adminName` unused

### DIFF
--- a/modules/vault-policies.nix
+++ b/modules/vault-policies.nix
@@ -6,7 +6,6 @@ let
     listToAttrs flip forEach;
   inherit (lib.types) listOf enum attrsOf str submodule nullOr;
   inherit (pkgs) ensureDependencies;
-  inherit (config.cluster) adminNames;
 
   rmModules = arg:
     let


### PR DESCRIPTION
- Maybe it originally was intended to add `root` policy privilige.
- Anyway: it's not used.
