### PR TITLE
Revert default filesystem mounts to 21.05 compatible mountpoints

### DIFF
--- a/modules/boot.nix
+++ b/modules/boot.nix
@@ -1,0 +1,41 @@
+{ pkgs, lib, config, ... }:
+
+with lib;
+
+let
+  cfg = config.bitte;
+  poolName = config.zfs.poolName;
+in {
+  options.bitte.nixosAmiSeparateBootPartition = {
+    enable = mkEnableOption "Use the new nixos 21.11 ami boot partition scheme";
+  };
+
+  config = mkIf cfg.nixosAmiSeparateBootPartition.enable {
+    # nixos-21.11pre and after behavior
+    boot.loader.grub.devices = lib.mkOverride 10 [ "/dev/xvda" ];
+
+    fileSystems = lib.mkForce {
+      "/" = {
+        fsType = "zfs";
+        device = "${poolName}/system/root";
+      };
+      "/home" = {
+        fsType = "zfs";
+        device = "${poolName}/user/home";
+      };
+      "/nix" = {
+        fsType = "zfs";
+        device = "${poolName}/local/nix";
+      };
+      "/var" = {
+        fsType = "zfs";
+        device = "${poolName}/system/var";
+      };
+      "/boot" = {
+        fsType = "vfat";
+        device = "/dev/disk/by-label/ESP";
+      };
+    };
+  };
+
+}

--- a/profiles/common.nix
+++ b/profiles/common.nix
@@ -16,7 +16,7 @@
   };
 
   fileSystems."/".device = lib.mkDefault "/dev/disk/by-label/nixos";
-  boot.loader.grub.devices = lib.mkForce [ "/dev/xvda" ];
+  boot.loader.grub.devices = [ "/dev/nvme0n1" ];
 
   environment.variables = { AWS_DEFAULT_REGION = config.cluster.region; };
 

--- a/profiles/zfs-runtime.nix
+++ b/profiles/zfs-runtime.nix
@@ -19,28 +19,26 @@ in {
       zfs.devNodes = "/dev/";
       kernelParams = [ "console=ttyS0" ];
     };
+
     fileSystems = {
       "/" = {
         fsType = "zfs";
-        device = "${poolName}/system/root";
+        device = "${poolName}/root";
       };
       "/home" = {
         fsType = "zfs";
-        device = "${poolName}/user/home";
+        device = "${poolName}/home";
       };
       "/nix" = {
         fsType = "zfs";
-        device = "${poolName}/local/nix";
+        device = "${poolName}/nix";
       };
       "/var" = {
         fsType = "zfs";
-        device = "${poolName}/system/var";
-      };
-      "/boot" = {
-        fsType = "vfat";
-        device = "/dev/disk/by-label/ESP";
+        device = "${poolName}/var";
       };
     };
+
     networking = {
       hostName = lib.mkDefault "";
       # xen host on aws


### PR DESCRIPTION
Until the default ami has support for the new mountpoints, use old behavior, but allow people to opt-in to the behavior with 
`bitte.nixosAmiSeparateBootPartition.enable`

cc @johnalotoski 