### PR TITLE
Fixes cert rotation on consul backended Vault clusters

### DIFF
--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -10,6 +10,13 @@
 
   services.amazon-ssm-agent.enable = true;
 
+  services.vault.storage.consul = lib.mkDefault {
+    address = "127.0.0.1:8500";
+    tlsCaFile = "/etc/ssl/certs/full.pem";
+    tlsCertFile = "/etc/ssl/certs/cert.pem";
+    tlsKeyFile = "/var/lib/vault/cert-key.pem";
+  };
+
   services.vault-agent-core = {
     enable = true;
     vaultAddress = "https://${config.cluster.instances.core-1.privateIP}:8200";


### PR DESCRIPTION
* ACME service on routing now generates certs instead of TF.
* `acme-routing.service` pushes kv secrets to `kv/bootstrap/letsencrypt/...` post cert generation, requiring properly running vault or vault-agent, but:
* Routing utilizes a vault-agent-core role, which has no listener, making a working vault daemon necessary.
* Routing utilizes a vault client role, which declares no backend storage by default and fails to start, thereby failing acme's push to kv storage.
* This PR leaves routing in the vault client role and just adds mkDefault of consul backend storage which could be overridden if a cluster uses raft instead.
* Other solutions on routing could be: add a vault-agent-core listener; switch to a vault-agent-client role