### PR TITLE
Adds overrides to zfs fs defns 

### DIFF
--- a/modules/boot.nix
+++ b/modules/boot.nix
@@ -14,7 +14,7 @@ in {
     # nixos-21.11pre and after behavior
     boot.loader.grub.devices = lib.mkOverride 10 [ "/dev/xvda" ];
 
-    fileSystems = lib.mkForce {
+    fileSystems = lib.mkOverride 10 {
       "/" = {
         fsType = "zfs";
         device = "${poolName}/system/root";

--- a/profiles/zfs-runtime.nix
+++ b/profiles/zfs-runtime.nix
@@ -20,7 +20,7 @@ in {
       kernelParams = [ "console=ttyS0" ];
     };
 
-    fileSystems = {
+    fileSystems = mkForce {
       "/" = {
         fsType = "zfs";
         device = "${poolName}/root";


### PR DESCRIPTION
* Adding back amazon-image.nix adds the nvme driver, but also an fs
  conflict on zfs clients.
* mkForce overrides the zfs defn conflict on legacy zfs clients.
* If `bitte.nixosAmiSeparateBootPartition.enable = true` a mkOverride
  will avoid conflict with both legacy client and amazon-image fs defns.

Note that bitte ops repos should also be using the zfs-runtime
from bitte rather than the older zfs-runtime from ops-lib.