### PR TITLE
Makes consul-default token static on clients

### DIFF
--- a/profiles/client.nix
+++ b/profiles/client.nix
@@ -16,7 +16,10 @@
     amazon-ssm-agent.enable = true;
     vault-agent-client = {
       enable = true;
-      disableTokenRotation = { consulAgent = true; };
+      disableTokenRotation = {
+        consulAgent = true;
+        consulDefault = true;
+      };
     };
     vault.enable = lib.mkForce false;
     nomad.enable = true;


### PR DESCRIPTION
* Seems to avoid longer term, sporadic acl errors on rotation