### PR TITLE
Reduce hourly snap default to 48

### DIFF
--- a/modules/consul-snapshots.nix
+++ b/modules/consul-snapshots.nix
@@ -23,8 +23,8 @@ let
           The number of snapshots to keep.  A sensible value matched to the onCalendar
           interval parameter should be used.  Examples of sensible suggestions may be:
 
-            168 backupCount for "hourly" interval (1 week of backups)
-            30  backupCount for "daily" interval (1 month of backups)
+            48 backupCount for "hourly" interval (2 days of backups)
+            30 backupCount for "daily" interval (1 month of backups)
         '';
       };
 
@@ -93,7 +93,7 @@ let
           defaults for backupCount and randomizedDelaySec should match this parameter.
           Examples of sensible suggestions may be:
 
-            hourly: 3600 randomizedDelaySec, 168 backupCount (1 week)
+            hourly: 3600 randomizedDelaySec, 48 backupCount (2 days)
             daily:  86400 randomizedDelaySec, 30 backupCount (1 month)
         '';
       };
@@ -204,7 +204,7 @@ in {
       enable = mkEnableOption ''
         Enable Consul snapshots.
 
-        By default hourly snapshots will be taken and stored for 1 week on each consul server.
+        By default hourly snapshots will be taken and stored for 2 days on each consul server.
         Modify services.consul-snapshots.hourly options to customize or disable.
 
         By default daily snapshots will be taken and stored for 1 month on each consul server.
@@ -218,7 +218,7 @@ in {
         type = snapshotJobConfig;
         default = {
           enable = true;
-          backupCount = 168;
+          backupCount = 48;
           backupSuffix = "hourly";
           interval = "hourly";
           randomizedDelaySec = 3600;

--- a/modules/nomad-snapshots.nix
+++ b/modules/nomad-snapshots.nix
@@ -23,8 +23,8 @@ let
           The number of snapshots to keep.  A sensible value matched to the onCalendar
           interval parameter should be used.  Examples of sensible suggestions may be:
 
-            168 backupCount for "hourly" interval (1 week of backups)
-            30  backupCount for "daily" interval (1 month of backups)
+            48 backupCount for "hourly" interval (2 days of backups)
+            30 backupCount for "daily" interval (1 month of backups)
         '';
       };
 
@@ -85,7 +85,7 @@ let
           defaults for backupCount and randomizedDelaySec should match this parameter.
           Examples of sensible suggestions may be:
 
-            hourly: 3600 randomizedDelaySec, 168 backupCount (1 week)
+            hourly: 3600 randomizedDelaySec, 48 backupCount (2 days)
             daily:  86400 randomizedDelaySec, 30 backupCount (1 month)
         '';
       };
@@ -218,7 +218,7 @@ in {
       enable = mkEnableOption ''
         Enable Nomad snapshots.
 
-        By default hourly snapshots will be taken and stored for 1 week on each nomad server.
+        By default hourly snapshots will be taken and stored for 2 days on each nomad server.
         Modify services.nomad-snapshots.hourly options to customize or disable.
 
         By default daily snapshots will be taken and stored for 1 month on each nomad server.
@@ -232,7 +232,7 @@ in {
         type = snapshotJobConfig;
         default = {
           enable = true;
-          backupCount = 168;
+          backupCount = 48;
           backupSuffix = "hourly";
           interval = "hourly";
           randomizedDelaySec = 3600;

--- a/modules/vault-snapshots.nix
+++ b/modules/vault-snapshots.nix
@@ -23,8 +23,8 @@ let
           The number of snapshots to keep.  A sensible value matched to the onCalendar
           interval parameter should be used.  Examples of sensible suggestions may be:
 
-            168 backupCount for "hourly" interval (1 week of backups)
-            30  backupCount for "daily" interval (1 month of backups)
+            48 backupCount for "hourly" interval (2 days of backups)
+            30 backupCount for "daily" interval (1 month of backups)
         '';
       };
 
@@ -85,7 +85,7 @@ let
           defaults for backupCount and randomizedDelaySec should match this parameter.
           Examples of sensible suggestions may be:
 
-            hourly: 3600 randomizedDelaySec, 168 backupCount (1 week)
+            hourly: 3600 randomizedDelaySec, 48 backupCount (2 days)
             daily:  86400 randomizedDelaySec, 30 backupCount (1 month)
         '';
       };
@@ -223,7 +223,7 @@ in {
       enable = mkEnableOption ''
         Enable Vault snapshots.
 
-        By default hourly snapshots will be taken and stored for 1 week on each vault server.
+        By default hourly snapshots will be taken and stored for 2 days on each vault server.
         Modify services.vault-snapshots.hourly options to customize or disable.
 
         By default daily snapshots will be taken and stored for 1 month on each vault server.
@@ -237,7 +237,7 @@ in {
         type = snapshotJobConfig;
         default = {
           enable = true;
-          backupCount = 168;
+          backupCount = 48;
           backupSuffix = "hourly";
           interval = "hourly";
           randomizedDelaySec = 3600;


### PR DESCRIPTION
* Reduce hourly snaps default from 168 (1 week) to 48 (2 days) for consul, nomad, vault snaps.
* This is to accommodate the fact that even some new cluster installs have rather large snap sizes.
* To override a snap backup jobset (hourly, daily, or custom), either redefine all required options for the jobset , or over-ride select pre-defined parameters as needed, example:
```
  services.consul-snapshots.hourly = recursiveUpdate config.services.consul-snapshots.hourly { backupCount = 24; };
```