### PR TITLE
Remove dead code

### DIFF
--- a/modules/terraform/clients.nix
+++ b/modules/terraform/clients.nix
@@ -30,19 +30,6 @@ in {
         roles = lib.flip lib.mapAttrs config.cluster.iam.roles
           (name: role: { arn = var "data.aws_iam_role.${role.uid}.arn"; });
 
-        instances = lib.flip lib.mapAttrs config.cluster.instances
-          (name: server: {
-            flake-attr =
-              "nixosConfigurations.${server.uid}.config.system.build.toplevel";
-            instance-type =
-              var "data.aws_instance.${server.name}.instance_type";
-            name = server.name;
-            private-ip = var "data.aws_instance.${server.name}.private_ip";
-            public-ip = var "data.aws_instance.${server.name}.public_ip";
-            tags = server.tags;
-            uid = server.uid;
-          });
-
         asgs = lib.flip lib.mapAttrs config.cluster.autoscalingGroups
           (name: group: {
             flake-attr =
@@ -56,14 +43,6 @@ in {
           });
       };
     };
-
-    data.aws_instance = lib.flip lib.mapAttrs config.cluster.instances
-      (name: server: {
-        filter = [{
-          name = "tag:UID";
-          values = [ server.uid ];
-        }];
-      });
 
     provider.aws = [{ region = config.cluster.region; }] ++ (lib.forEach regions
       (region: {

--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -45,8 +45,6 @@ in {
             tags = server.tags;
             uid = server.uid;
           });
-
-        asgs = { };
       };
     };
 


### PR DESCRIPTION
- instance (="core") outputs in the clients workspace seems misplaced
- so do clients outputs in the core workspace
