### PR TITLE
Routing prometheus metrics with dashboard

### DIFF
--- a/modules/consul.nix
+++ b/modules/consul.nix
@@ -1,6 +1,7 @@
 { config, lib, pkgs, ... }:
 let
   cfg = config.services.consul;
+  inherit (builtins) elem;
   inherit (lib)
     mkIf pipe filterAttrs mapAttrs' nameValuePair flip concatMapStrings isList
     toLower mapAttrsToList hasPrefix mkEnableOption mkOption makeBinPath;
@@ -30,10 +31,11 @@ let
     };
 
   # Some config cannot be snakeCase sanitized without breaking the functionality.
-  # Example: consul service resolver subsets
-  sanitizeName = name: if name == "subsets" then name else snakeCase name;
+  # Example: consul service router, resolver and splitter configuration.
+  excluded = [ "failover" "splits" "subsets" ];
+  sanitizeName = name: if elem name excluded then name else snakeCase name;
   sanitizeValue = name: value:
-    if name == "subsets" then value else sanitize value;
+    if elem name excluded then value else sanitize value;
 
 in {
   options = {

--- a/pkgs/victoriametrics.nix
+++ b/pkgs/victoriametrics.nix
@@ -1,20 +1,26 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ pkgs, lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   pname = "VictoriaMetrics";
-  version = "1.49.0";
+  version = "1.68.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "1aa9dlz2b757xzn0plix7p115kxh5rpa12ad86wzybxs778wgb4n";
+    sha256 = "sha256-nTRlJISFyX42PCRWKH1tONFCQtAJ00fKw6521VDhvd0=";
   };
 
   goPackagePath = "github.com/VictoriaMetrics/VictoriaMetrics";
 
   buildFlagsArray =
     [ "-ldflags=-s -w -X ${goPackagePath}/lib/buildinfo.Version=${version}" ];
+
+  # Avoid building the vmui component for now which requires a docker build
+  preBuild = ''
+    cd go/src/github.com/VictoriaMetrics/VictoriaMetrics/app/vmui/packages/vmui/web/
+    touch asset-manifest.json index.html favicon-32x32.png manifest.json robots.txt static
+  '';
 
   meta = with lib; {
     homepage = "https://victoriametrics.com/";

--- a/profiles/monitoring/traefik.json
+++ b/profiles/monitoring/traefik.json
@@ -1,0 +1,1287 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Traefik dashboard prometheus",
+  "editable": true,
+  "gnetId": 4475,
+  "graphTooltip": 0,
+  "id": 69,
+  "iteration": 1635453930723,
+  "links": [],
+  "panels": [
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "title": "$service stats",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "VictoriaMetrics",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": null,
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {}
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "prometheus_traefik_service_requests_total{host=\"$traefikHost\",service=\"$service\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}} : {{code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Return Codes For $service",
+      "type": "piechart"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "VictoriaMetrics",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "format": "ms",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": null,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(prometheus_traefik_service_request_duration_seconds_sum{host=\"$traefikHost\",service=\"$service\"}) / sum(prometheus_traefik_service_requests_total{host=\"$traefikHost\",service=\"$service\"}) * 1000",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Average Response Time For $service",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "VictoriaMetrics",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.10",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(prometheus_traefik_service_requests_total{host=\"$traefikHost\",service=\"$service\"}[1m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "$service",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total non-TLS Requests To $service Per Minute",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:91",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:92",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "VictoriaMetrics",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 17,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.10",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(prometheus_traefik_service_requests_tls_total{host=\"$traefikHost\",service=\"$service\"}[1m])) by (tls_cipher, tls_version)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{tls_cipher}} : {{tls_version}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total TLS Requests To $service Per Minute",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:91",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:92",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cards": {
+        "cardPadding": null,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "timeseries",
+      "datasource": "VictoriaMetrics",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 15,
+      "legend": {
+        "show": false
+      },
+      "links": [],
+      "pluginVersion": "7.5.10",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(prometheus_buckets(prometheus_traefik_service_request_duration_seconds_bucket{host=\"$traefikHost\",service=\"$service\"})[1m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "$service",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Request Duration Heat Map To $service",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "short",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "VictoriaMetrics",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.10",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "prometheus_traefik_config_reloads_total{host=\"$traefikHost\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{__name__}}",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "prometheus_traefik_config_reloads_failure_total{host=\"$traefikHost\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{__name__}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Traefik Configuration Reload Metrics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:360",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:361",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Global stats",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "VictoriaMetrics",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.10",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(prometheus_traefik_entrypoint_requests_total{host=\"$traefikHost\",entrypoint=~\"$entrypoint\",code=\"200\"}[1m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{entrypoint}} : {{method}} : {{code}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Entrypoint Status Code 200 Per Minute",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:143",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:144",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "VictoriaMetrics",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.10",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(prometheus_traefik_entrypoint_requests_total{host=\"$traefikHost\",entrypoint=~\"$entrypoint\",code!=\"200\"}[1m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{entrypoint}} : {{method}} : {{code}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Entrypoint Others Status Code Per Minute",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:195",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:196",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "VictoriaMetrics",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 7,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": null,
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {}
+      },
+      "pluginVersion": "7.5.10",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(prometheus_traefik_service_requests_total{host=\"$traefikHost\"}[1m])) by (service)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{ service }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests By Service Per Minute",
+      "type": "piechart"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "VictoriaMetrics",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 8,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": null,
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {}
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(prometheus_traefik_entrypoint_requests_total{host=\"$traefikHost\",entrypoint =~ \"$entrypoint\"}[1m])) by (entrypoint) ",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{ entrypoint }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests By Entrypoint Per Minute",
+      "type": "piechart"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "VictoriaMetrics",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.10",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "prometheus_traefik_service_open_connections{host=\"$traefikHost\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{service}} : {{method}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Service Open Connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:360",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:361",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "VictoriaMetrics",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.10",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "prometheus_traefik_entrypoint_open_connections{host=\"$traefikHost\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{entrypoint}} : {{method}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Entrypoint Open Connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:565",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:566",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "routing",
+          "value": "routing"
+        },
+        "datasource": "VictoriaMetrics",
+        "definition": "label_values(prometheus_traefik_config_reloads_total, host)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "traefikHost",
+        "multi": false,
+        "name": "traefikHost",
+        "options": [],
+        "query": {
+          "query": "label_values(prometheus_traefik_config_reloads_total, host)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "oauth-backend@file",
+          "value": "oauth-backend@file"
+        },
+        "datasource": "VictoriaMetrics",
+        "definition": "label_values(service)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "service",
+        "options": [],
+        "query": {
+          "query": "label_values(service)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/.*@.*/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "VictoriaMetrics",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "entrypoint",
+        "options": [],
+        "query": {
+          "query": "label_values(entrypoint)",
+          "refId": "Prometheus-entrypoint-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Traefik [Bitte]",
+  "uid": "qPdAviJmz",
+  "version": 1
+}

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -1,4 +1,5 @@
 { self, lib, pkgs, config, nodeName, ... }: {
+
   imports = [
     ./common.nix
     ./consul/client.nix
@@ -8,159 +9,170 @@
     ./vault/client.nix
   ];
 
-  services.amazon-ssm-agent.enable = true;
-  services.vault-agent-monitoring.enable = true;
-
-  systemd.services.copy-acme-certs = {
-    before = [ "traefik.service" ];
-    wantedBy = [ "traefik.service" ];
-
-    serviceConfig = {
-      Type = "oneshot";
-      RemainAfterExit = false;
-      Restart = "on-failure";
-      RestartSec = "30s";
-    };
-
-    path = [ pkgs.coreutils ];
-
-    script = ''
-      set -exuo pipefail
-
-      mkdir -p /var/lib/traefik/certs
-      cp /etc/ssl/certs/${config.cluster.domain}-*.pem /var/lib/traefik/certs
-      chown -R traefik:traefik /var/lib/traefik
-    '';
+  options.services.traefik.prometheusPort = lib.mkOption {
+    type = lib.types.int;
+    default = 8082;
+    description =
+      "The default port for traefik prometheus to publish metrics on.";
   };
 
-  security.acme = {
-    acceptTerms = true;
-    certs.routing = lib.mkIf (nodeName == "routing") {
-      dnsProvider = "route53";
-      dnsResolver = "1.1.1.1:53";
-      email = "devops@iohk.io";
-      domain = config.cluster.domain;
-      credentialsFile = builtins.toFile "nothing" "";
-      extraDomainNames = [ "*.${config.cluster.domain}" ]
-        ++ config.cluster.extraAcmeSANs;
-      postRun = ''
-        cp fullchain.pem /etc/ssl/certs/${config.cluster.domain}-full.pem
-        cp key.pem /etc/ssl/certs/${config.cluster.domain}-key.pem
-        systemctl try-restart --no-block traefik.service
+  config = {
 
-        export VAULT_TOKEN="$(< /run/keys/vault-token)"
-        export VAULT_ADDR="http://127.0.0.1:8200"
-        ${pkgs.vault}/bin/vault kv put kv/bootstrap/letsencrypt/key value=@key.pem
-        ${pkgs.vault}/bin/vault kv put kv/bootstrap/letsencrypt/fullchain value=@fullchain.pem
-        ${pkgs.vault}/bin/vault kv put kv/bootstrap/letsencrypt/cert value=@cert.pem
+    services.amazon-ssm-agent.enable = true;
+    services.vault-agent-monitoring.enable = true;
+
+    systemd.services.copy-acme-certs = {
+      before = [ "traefik.service" ];
+      wantedBy = [ "traefik.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = false;
+        Restart = "on-failure";
+        RestartSec = "30s";
+      };
+
+      path = [ pkgs.coreutils ];
+
+      script = ''
+        set -exuo pipefail
+
+        mkdir -p /var/lib/traefik/certs
+        cp /etc/ssl/certs/${config.cluster.domain}-*.pem /var/lib/traefik/certs
+        chown -R traefik:traefik /var/lib/traefik
       '';
     };
-  };
 
-  services.traefik = {
-    enable = true;
+    security.acme = {
+      acceptTerms = true;
+      certs.routing = lib.mkIf (nodeName == "routing") {
+        dnsProvider = "route53";
+        dnsResolver = "1.1.1.1:53";
+        email = "devops@iohk.io";
+        domain = config.cluster.domain;
+        credentialsFile = builtins.toFile "nothing" "";
+        extraDomainNames = [ "*.${config.cluster.domain}" ]
+          ++ config.cluster.extraAcmeSANs;
+        postRun = ''
+          cp fullchain.pem /etc/ssl/certs/${config.cluster.domain}-full.pem
+          cp key.pem /etc/ssl/certs/${config.cluster.domain}-key.pem
+          systemctl try-restart --no-block traefik.service
 
-    dynamicConfigOptions = {
-      tls.certificates = [{
-        certFile = "/var/lib/traefik/certs/${config.cluster.domain}-full.pem";
-        keyFile = "/var/lib/traefik/certs/${config.cluster.domain}-key.pem";
-      }];
-
-      http = {
-        routers = {
-          traefik = {
-            rule = "Host(`routing.${config.cluster.domain}`)";
-            service = "api@internal";
-            entrypoints = "https";
-            tls = true;
-          };
-        };
+          export VAULT_TOKEN="$(< /run/keys/vault-token)"
+          export VAULT_ADDR="http://127.0.0.1:8200"
+          ${pkgs.vault}/bin/vault kv put kv/bootstrap/letsencrypt/key value=@key.pem
+          ${pkgs.vault}/bin/vault kv put kv/bootstrap/letsencrypt/fullchain value=@fullchain.pem
+          ${pkgs.vault}/bin/vault kv put kv/bootstrap/letsencrypt/cert value=@cert.pem
+        '';
       };
     };
 
-    staticConfigOptions = {
-      metrics.influxDB = {
-        address =
-          "http://${config.cluster.instances.monitoring.privateIP}:8428";
-        protocol = "http";
-        database = "traefik";
-        addEntryPointsLabels = true;
-        addServicesLabels = true;
-        pushInterval = "10s";
-      };
+    services.traefik = {
+      enable = true;
 
-      api = { dashboard = true; };
+      dynamicConfigOptions = {
+        tls.certificates = [{
+          certFile = "/var/lib/traefik/certs/${config.cluster.domain}-full.pem";
+          keyFile = "/var/lib/traefik/certs/${config.cluster.domain}-key.pem";
+        }];
 
-      entryPoints = {
         http = {
-          address = ":80";
-          http = {
-            redirections = {
-              entryPoint = {
-                scheme = "https";
-                to = "https";
-              };
+          routers = {
+            traefik = {
+              rule = "Host(`routing.${config.cluster.domain}`)";
+              service = "api@internal";
+              entrypoints = "https";
+              tls = true;
             };
           };
         };
-
-        https = { address = ":443"; };
       };
 
-      providers.consulCatalog = {
-        refreshInterval = "30s";
-
-        prefix = "traefik";
-
-        # Forces the read to be fully consistent.
-        requireConsistent = true;
-
-        # Use stale consistency for catalog reads.
-        stale = false;
-
-        # Use local agent caching for catalog reads.
-        cache = false;
-
-        endpoint = {
-          # Defines the address of the Consul server.
-          address = "127.0.0.1:${toString config.services.consul.ports.http}";
-
-          scheme = "http";
-
-          # Defines the datacenter to use. If not provided in Traefik, Consul uses the default agent datacenter.
-          datacenter = config.cluster.region;
-
-          # Token is used to provide a per-request ACL token which overwrites the agent's default token.
-          # token = ""
-
-          # Limits the duration for which a Watch can block. If not provided, the agent default values will be used.
-          # endpointWaitTime = "1s";
+      staticConfigOptions = {
+        metrics.prometheus = {
+          entrypoint = "metrics";
+          addEntryPointsLabels = true;
+          addServicesLabels = true;
         };
 
-        # Expose Consul Catalog services by default in Traefik. If set to false, services that don't have a traefik.enable=true tag will be ignored from the resulting routing configuration.
-        exposedByDefault = false;
+        api = { dashboard = true; };
 
-        # The default host rule for all services.
-        # For a given service, if no routing rule was defined by a tag, it is
-        # defined by this defaultRule instead. The defaultRule must be set to a
-        # valid Go template, and can include sprig template functions. The
-        # service name can be accessed with the Name identifier, and the template
-        # has access to all the labels (i.e. tags beginning with the prefix)
-        # defined on this service.
-        # The option can be overridden on an instance basis with the
-        # traefik.http.routers.{name-of-your-choice}.rule tag.
-        # Default=Host(`{{ normalize .Name }}`)
-        # defaultRule = ''Host(`{{ .Name }}.{{ index .Labels "customLabel"}}`)'';
-        defaultRule = "Host(`{{ normalize .Name }}`)";
+        entryPoints = {
+          http = {
+            address = ":80";
+            http = {
+              redirections = {
+                entryPoint = {
+                  scheme = "https";
+                  to = "https";
+                };
+              };
+            };
+          };
 
-        # The constraints option can be set to an expression that Traefik matches
-        # against the service tags to determine whether to create any route for that
-        # service. If none of the service tags match the expression, no route for that
-        # service is created. If the expression is empty, all detected services are
-        # included.
-        # The expression syntax is based on the Tag(`tag`), and TagRegex(`tag`)
-        # functions, as well as the usual boolean logic.
-        constraints = "Tag(`ingress`)";
+          https = { address = ":443"; };
+
+          metrics = {
+            address =
+              "127.0.0.1:${toString config.services.traefik.prometheusPort}";
+          };
+        };
+
+        providers.consulCatalog = {
+          refreshInterval = "30s";
+
+          prefix = "traefik";
+
+          # Forces the read to be fully consistent.
+          requireConsistent = true;
+
+          # Use stale consistency for catalog reads.
+          stale = false;
+
+          # Use local agent caching for catalog reads.
+          cache = false;
+
+          endpoint = {
+            # Defines the address of the Consul server.
+            address = "127.0.0.1:${toString config.services.consul.ports.http}";
+
+            scheme = "http";
+
+            # Defines the datacenter to use. If not provided in Traefik, Consul uses the default agent datacenter.
+            datacenter = config.cluster.region;
+
+            # Token is used to provide a per-request ACL token which overwrites the agent's default token.
+            # token = ""
+
+            # Limits the duration for which a Watch can block. If not provided, the agent default values will be used.
+            # endpointWaitTime = "1s";
+          };
+
+          # Expose Consul Catalog services by default in Traefik. If set to false, services that don't have a traefik.enable=true tag will be ignored from the resulting routing configuration.
+          exposedByDefault = false;
+
+          # The default host rule for all services.
+          # For a given service, if no routing rule was defined by a tag, it is
+          # defined by this defaultRule instead. The defaultRule must be set to a
+          # valid Go template, and can include sprig template functions. The
+          # service name can be accessed with the Name identifier, and the template
+          # has access to all the labels (i.e. tags beginning with the prefix)
+          # defined on this service.
+          # The option can be overridden on an instance basis with the
+          # traefik.http.routers.{name-of-your-choice}.rule tag.
+          # Default=Host(`{{ normalize .Name }}`)
+          # defaultRule = ''Host(`{{ .Name }}.{{ index .Labels "customLabel"}}`)'';
+          defaultRule = "Host(`{{ normalize .Name }}`)";
+
+          # The constraints option can be set to an expression that Traefik matches
+          # against the service tags to determine whether to create any route for that
+          # service. If none of the service tags match the expression, no route for that
+          # service is created. If the expression is empty, all detected services are
+          # included.
+          # The expression syntax is based on the Tag(`tag`), and TagRegex(`tag`)
+          # functions, as well as the usual boolean logic.
+          constraints = "Tag(`ingress`)";
+        };
       };
     };
   };

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -11,7 +11,7 @@
 
   options.services.traefik.prometheusPort = lib.mkOption {
     type = lib.types.int;
-    default = 8082;
+    default = 9090;
     description =
       "The default port for traefik prometheus to publish metrics on.";
   };

--- a/profiles/telegraf.nix
+++ b/profiles/telegraf.nix
@@ -76,10 +76,14 @@ in {
               toString
               config.services.loki.configuration.server.http_listen_port
             }/metrics";
+          traefik = "http://127.0.0.1:${
+              toString config.services.traefik.prometheusPort
+            }/metrics";
         in {
           urls = optional config.services.promtail.enable promtail
             ++ optional config.services.loki.enable loki
-            ++ optional config.services.nomad-autoscaler.enable autoscaling;
+            ++ optional config.services.nomad-autoscaler.enable autoscaling
+            ++ optional config.services.traefik.enable traefik;
           metric_version = 2;
         };
 


### PR DESCRIPTION
* Convert traefik metrics to prom for bucket data
* Adds a traefik dash with host selection to accommodate multiple traefik instances
* Set default prom listener port to standard 9090, configurable with `services.traefik.prometheusPort`
* Bumps victoria-metrics 1.49.0 -> 1.68.0, with build exclusion of vmui component
* Adds addnl sanitization exclusions for consul config