### PR TITLE
modules/consul: avoid IFD with policies

### DIFF
--- a/modules/consul-policies.nix
+++ b/modules/consul-policies.nix
@@ -122,9 +122,8 @@ let
         apply = _:
           let
             json = toJSON this.config._computed;
-            mini = pkgs.writeText "consul-policy.mini.json" json;
           in pkgs.runCommandNoCCLocal "consul-policy.json" { } ''
-            ${pkgs.jq}/bin/jq -S < ${mini} > $out
+            echo ${json} | ${pkgs.jq}/bin/jq -S > $out
           '';
       };
 


### PR DESCRIPTION
the `toJSON` builting should be returning this as a quoted string

```
$ nix-instantiate --eval --expr 'builtins.toJSON { b = 5; a = 3;}'
"{\"a\":3,\"b\":5}"
```

Thus we shouldn't need to write it to a file.

Also, writing it to a file, then reading it back is considered IFD in some situations.