### PR TITLE
Adds aws premSim

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org' do
+  gem 'ed25519'
+  gem 'pry'
+  gem 'rake'
+  gem 'ssh_data'
+  gem 'toml-rb'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,30 @@
+GEM
+  specs:
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    citrus (3.0.2)
+    coderay (1.1.3)
+    ed25519 (1.2.4)
+    method_source (1.0.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rake (13.0.6)
+    ssh_data (1.2.0)
+    toml-rb (2.1.0)
+      citrus (~> 3.0, > 3.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  ed25519!
+  pry!
+  rake!
+  ssh_data!
+  toml-rb!
+
+BUNDLED WITH
+   2.2.24

--- a/flake.lock
+++ b/flake.lock
@@ -2,6 +2,47 @@
   "nodes": {
     "agenix": {
       "inputs": {
+        "nixpkgs": [
+          "nixpkgs-auxiliary"
+        ]
+      },
+      "locked": {
+        "lastModified": 1641576265,
+        "narHash": "sha256-G4W39k5hdu2kS13pi/RhyTOySAo7rmrs7yMUZRH0OZI=",
+        "owner": "ryantm",
+        "repo": "agenix",
+        "rev": "08b9c96878b2f9974fc8bde048273265ad632357",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryantm",
+        "repo": "agenix",
+        "type": "github"
+      }
+    },
+    "agenix-cli": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs-auxiliary"
+        ]
+      },
+      "locked": {
+        "lastModified": 1641404293,
+        "narHash": "sha256-0+QVY1sDhGF4hAN6m2FdKZgm9V1cuGGjY4aitRBnvKg=",
+        "owner": "cole-h",
+        "repo": "agenix-cli",
+        "rev": "77fccec4ed922a0f5f55ed964022b0db7d99f07d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cole-h",
+        "repo": "agenix-cli",
+        "type": "github"
+      }
+    },
+    "agenix_2": {
+      "inputs": {
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
@@ -187,11 +228,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1610051610,
-        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {
@@ -202,11 +243,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1610051610,
+        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
         "type": "github"
       },
       "original": {
@@ -232,6 +273,21 @@
     },
     "flake-utils_4": {
       "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "locked": {
         "lastModified": 1637014545,
         "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
         "owner": "numtide",
@@ -245,7 +301,7 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
+    "flake-utils_6": {
       "locked": {
         "lastModified": 1634851050,
         "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
@@ -568,8 +624,8 @@
     },
     "ragenix": {
       "inputs": {
-        "agenix": "agenix",
-        "flake-utils": "flake-utils_2",
+        "agenix": "agenix_2",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
           "nixpkgs-auxiliary"
         ],
@@ -591,6 +647,8 @@
     },
     "root": {
       "inputs": {
+        "agenix": "agenix",
+        "agenix-cli": "agenix-cli",
         "blank": "blank",
         "cli": "cli",
         "deploy": "deploy",
@@ -635,7 +693,7 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
@@ -654,7 +712,7 @@
     },
     "rust-overlay_2": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_5",
         "nixpkgs": [
           "nixpkgs-core"
         ]
@@ -692,7 +750,7 @@
       "inputs": {
         "bats-assert": "bats-assert",
         "bats-support": "bats-support",
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_6",
         "nixpkgs": [
           "blank"
         ],
@@ -729,7 +787,7 @@
     },
     "treefmt": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,11 @@
     cli.inputs.nixpkgs.follows = "nixpkgs-auxiliary";
     cli.inputs.nix.follows = "nix-auxiliary";
 
+    agenix.url = "github:ryantm/agenix";
+    agenix.inputs.nixpkgs.follows = "nixpkgs-auxiliary";
+    agenix-cli.url = "github:cole-h/agenix-cli";
+    agenix-cli.inputs.nixpkgs.follows = "nixpkgs-auxiliary";
+
     ragenix.url = "github:yaxitech/ragenix";
     ragenix.inputs.nixpkgs.follows = "nixpkgs-auxiliary";
 

--- a/flake.nix
+++ b/flake.nix
@@ -120,7 +120,8 @@
       overlay = nixpkgs.lib.composeManyExtensions overlays;
       profiles = lib.mkModules ./profiles;
       nixosModules = (lib.mkModules ./modules) // {
-        agenix = ragenix.nixosModules.age;
+        # Until ready to update to the new age module options
+        # agenix = ragenix.nixosModules.age;
       };
       nixosModule.imports = builtins.attrValues self.nixosModules;
     };

--- a/gemset.nix
+++ b/gemset.nix
@@ -1,0 +1,84 @@
+{
+  citrus = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0l7nhk3gkm1hdchkzzhg2f70m47pc0afxfpl6mkiibc9qcpl3hjf";
+      type = "gem";
+    };
+    version = "3.0.2";
+  };
+  coderay = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jvxqxzply1lwp7ysn94zjhh57vc14mcshw1ygw14ib8lhc00lyw";
+      type = "gem";
+    };
+    version = "1.1.3";
+  };
+  ed25519 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1f5kr8za7hvla38fc0n9jiv55iq62k5bzclsa5kdb14l3r4w6qnw";
+      type = "gem";
+    };
+    version = "1.2.4";
+  };
+  method_source = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pnyh44qycnf9mzi1j6fywd5fkskv3x7nmsqrrws0rjn5dd4ayfp";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  pry = {
+    dependencies = ["coderay" "method_source"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m445x8fwcjdyv2bc0glzss2nbm1ll51bq45knixapc7cl3dzdlr";
+      type = "gem";
+    };
+    version = "0.14.1";
+  };
+  rake = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15whn7p9nrkxangbs9hh75q585yfn66lv0v2mhj6q6dl6x8bzr2w";
+      type = "gem";
+    };
+    version = "13.0.6";
+  };
+  ssh_data = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0p3vaq2fbmlphphqr0yjc5cyzzxjizq4zbxbbw3j2vpgdcmpi6bs";
+      type = "gem";
+    };
+    version = "1.2.0";
+  };
+  toml-rb = {
+    dependencies = ["citrus"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1mrr8c9agmf9l9gs63lnsqzc62x08hj673yix7bjss1kvagwjnsr";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+}

--- a/lib/clusters.nix
+++ b/lib/clusters.nix
@@ -12,12 +12,23 @@ lib.listToAttrs (lib.forEach clusterFiles (file:
       modules = [ file hydrateModule ];
     }).bitteProtoSystem;
 
+    # Separating core and premSim nodes may cause bitte-cli tooling to break.
+    # Currently groupings are viewed as core or awsAsg.
+    # May be able to split premSim nodes out going forward.
+    coreAndPremSimNodes = assert (lib.assertMsg (!builtins.any
+      (e: builtins.elem e (builtins.attrNames _proto.config.cluster.coreNodes))
+      (builtins.attrNames _proto.config.cluster.premSimNodes)) ''
+        ERROR
+        trace: ERROR  -->  premSimNodes may not have the same names as coreNodes
+      '');
+      _proto.config.cluster.premSimNodes // _proto.config.cluster.coreNodes;
+
     coreNodes = lib.mapAttrs (nodeName: coreNode:
       (mkSystem {
         inherit pkgs self inputs nodeName;
         modules = [ { networking.hostName = lib.mkForce nodeName; } file hydrateModule ]
           ++ coreNode.modules;
-      }).bitteAmazonSystem) _proto.config.cluster.coreNodes;
+      }).bitteAmazonSystem) coreAndPremSimNodes;
 
     awsAutoScalingGroups = lib.mapAttrs (nodeName: awsAutoScalingGroup:
       (mkSystem {

--- a/lib/mk-system.nix
+++ b/lib/mk-system.nix
@@ -35,7 +35,7 @@ let
       ../profiles/auxiliaries/nix.nix
       ../profiles/consul/policies.nix
       # This module purely exists to appease failing assertions on evaluating
-      # the proto system. The protosystem is only used to obtaion the tf config.
+      # the proto system. The protosystem is only used to obtain the tf config.
       ({ lib, ... }: {
         # assertion: The ‘fileSystems’ option does not specify your root file system.
         fileSystems."/" =

--- a/lib/mk-system/constants-module.nix
+++ b/lib/mk-system/constants-module.nix
@@ -1,16 +1,31 @@
-{ config, ... }: {
+{ config, ... }:
+let
+  deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
+  domain = config.${if deployType == "aws" then "cluster" else "currentCoreNode"}.domain;
+in {
   _module.args = {
     pkiFiles = {
+      # Common deployType cert files
       caCertFile = "/etc/ssl/certs/ca.pem";
+
+      # "aws" deployType cert files
       certChainFile = "/etc/ssl/certs/full.pem";
       certFile = "/etc/ssl/certs/cert.pem";
       keyFile = "/etc/ssl/certs/cert-key.pem";
+
+      # "prem" and "premSim" deployType cert files
+      clientCertFile = "/etc/ssl/certs/client.pem";
+      clientKeyFile = "/etc/ssl/certs/client-key.pem";
+      clientCertChainFile = "/etc/ssl/certs/client-full.pem";
+      serverCertFile = "/etc/ssl/certs/server.pem";
+      serverKeyFile = "/etc/ssl/certs/server-key.pem";
+      serverCertChainFile = "/etc/ssl/certs/server-full.pem";
     };
 
     letsencryptCertMaterial = {
-      certFile = "/etc/ssl/certs/${config.cluster.domain}-cert.pem";
-      certChainFile = "/etc/ssl/certs/${config.cluster.domain}-full.pem";
-      keyFile = "/etc/ssl/certs/${config.cluster.domain}-key.pem";
+      certFile = "/etc/ssl/certs/${domain}-cert.pem";
+      certChainFile = "/etc/ssl/certs/${domain}-full.pem";
+      keyFile = "/etc/ssl/certs/${domain}-key.pem";
     };
 
     gossipEncryptionMaterial = {

--- a/modules/age.nix
+++ b/modules/age.nix
@@ -1,0 +1,151 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.age;
+
+  ageBin = "${pkgs.age}/bin/age";
+
+  users = config.users.users;
+
+  identities =
+    builtins.concatStringsSep " " (map (path: "-i ${path}") cfg.sshKeyPaths);
+  installSecret = secretType: ''
+    echo "decrypting ${secretType.file} to ${secretType.path}..."
+
+    TMP_FILE="${secretType.path}.tmp"
+    TMP_FILE2="${secretType.path}.tmp2"
+
+    mkdir -p $(dirname ${secretType.path})
+    (
+      umask u=r,g=,o=
+      LANG=${config.i18n.defaultLocale} ${ageBin} --decrypt ${identities} -o "$TMP_FILE" "${secretType.file}"
+      src="$TMP_FILE"
+      out="$TMP_FILE2"
+      ${secretType.script}
+      mv "$out" "$src"
+    )
+    chmod ${secretType.mode} "$TMP_FILE"
+    chown ${secretType.owner}:${secretType.group} "$TMP_FILE"
+    mv -f "$TMP_FILE" '${secretType.path}'
+  '';
+
+  isRootSecret = st:
+    (st.owner == "root" || st.owner == "0")
+    && (st.group == "root" || st.group == "0");
+  isNotRootSecret = st: !(isRootSecret st);
+
+  rootOwnedSecrets =
+    builtins.filter isRootSecret (builtins.attrValues cfg.secrets);
+  installRootOwnedSecrets = builtins.concatStringsSep "\n"
+    ([ "echo '[agenix] decrypting root secrets...'" ]
+      ++ (map installSecret rootOwnedSecrets));
+
+  nonRootSecrets =
+    builtins.filter isNotRootSecret (builtins.attrValues cfg.secrets);
+  installNonRootSecrets = builtins.concatStringsSep "\n"
+    ([ "echo '[agenix] decrypting non-root secrets...'" ]
+      ++ (map installSecret nonRootSecrets));
+
+  secretType = types.submodule ({ config, name, ... }: {
+    options = {
+      name = mkOption {
+        type = types.str;
+        default = name;
+        description = ''
+          Name of the file used in /run/secrets
+        '';
+      };
+
+      file = mkOption {
+        type = types.path;
+        description = ''
+          Age file the secret is loaded from.
+        '';
+      };
+
+      path = mkOption {
+        type = types.str;
+        default = "/run/secrets/${config.name}";
+        description = ''
+          Path where the decrypted secret is installed.
+        '';
+      };
+
+      script = mkOption {
+        type = types.str;
+        default = "mv $src $out";
+        description = ''
+          script to run on the encrypted file to transform it.
+        '';
+      };
+
+      mode = mkOption {
+        type = types.str;
+        default = "0400";
+        description = ''
+          Permissions mode of the in octal.
+        '';
+      };
+
+      owner = mkOption {
+        type = types.str;
+        default = "0";
+        description = ''
+          User of the file.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = users.${config.owner}.group or "0";
+        description = ''
+          Group of the file.
+        '';
+      };
+    };
+  });
+in
+{
+  options.age = {
+    encryptedRoot = lib.mkOption { type = types.path; };
+
+    secrets = mkOption {
+      type = types.attrsOf secretType;
+      default = { };
+      description = ''
+        Attrset of secrets.
+      '';
+    };
+
+    sshKeyPaths = mkOption {
+      type = types.listOf types.path;
+      default =
+        if config.services.openssh.enable then
+          map (e: e.path)
+            (lib.filter (e: e.type == "ed25519") config.services.openssh.hostKeys)
+        else
+          [ ];
+      description = ''
+        Path to SSH keys to be used as identities in age decryption.
+      '';
+    };
+  };
+  config = mkIf (cfg.secrets != { }) {
+    assertions = [{
+      assertion = cfg.sshKeyPaths != [ ];
+      message = "age.sshKeyPaths must be set.";
+    }];
+
+    # Secrets with root owner and group can be installed before users
+    # exist. This allows user password files to be encrypted.
+    system.activationScripts.agenixRoot =
+      stringAfter [ ] installRootOwnedSecrets;
+    system.activationScripts.users.deps = [ "agenixRoot" ];
+
+    # Other secrets need to wait for users and groups to exist.
+    system.activationScripts.agenix =
+      stringAfter [ "users" "groups" ] installNonRootSecrets;
+  };
+}

--- a/modules/consul.nix
+++ b/modules/consul.nix
@@ -498,6 +498,7 @@ in {
 
             set -x
             cd /var/lib/consul/
+            cp ${certChainFile} full.pem
             cp ${certKeyFile} cert-key.pem
             chown --reference . --recursive .
             consul reload

--- a/modules/consul.nix
+++ b/modules/consul.nix
@@ -1,6 +1,8 @@
-{ config, lib, pkgs, bittelib, hashiTokens, gossipEncryptionMaterial, ... }:
+{ config, lib, pkgs, bittelib, hashiTokens, gossipEncryptionMaterial, pkiFiles, ... }:
 let
   cfg = config.services.consul;
+
+  deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
 
   sanitize = obj:
     lib.getAttr (builtins.typeOf obj) {
@@ -56,6 +58,12 @@ in {
       logLevel = lib.mkOption {
         type = with lib.types; enum [ "trace" "debug" "info" "warn" "err" ];
         default = "info";
+      };
+
+      serverNodeNames = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = if deployType == "aws" then [ "core-1" "core-2" "core-3" ]
+                  else [ "prem-1" "prem-2" "prem-3" ];
       };
 
       extraConfig = lib.mkOption {
@@ -421,11 +429,16 @@ in {
       path = with pkgs; [ envoy ];
 
       serviceConfig = let
+        certChainFile = if deployType == "aws" then pkiFiles.certChainFile
+                        else pkiFiles.serverCertChainFile;
+        certKeyFile = if deployType == "aws" then pkiFiles.keyFile
+                      else pkiFiles.serverKeyFile;
         preScript = let
           start-pre = pkgs.writeBashBinChecked "consul-start-pre" ''
             PATH="${lib.makeBinPath [ pkgs.coreutils ]}"
             set -exuo pipefail
-            cp /etc/ssl/certs/cert-key.pem .
+            cp ${certChainFile} full.pem
+            cp ${certKeyFile} cert-key.pem
             chown --reference . --recursive .
           '';
         in "!${start-pre}/bin/consul-start-pre";
@@ -441,7 +454,7 @@ in {
             then
               CONSUL_HTTP_TOKEN="$(< ${hashiTokens.consul-default})"
               export CONSUL_HTTP_TOKEN
-            # Therefore, on core nodes, use the sops out-of-band bootstrapped master token
+            # Therefore, on core nodes, use the out-of-band bootstrapped master token
             elif [ -s ${gossipEncryptionMaterial.consul} ]
             then
               # as of writing: core nodes are observed to posess the master token
@@ -470,7 +483,7 @@ in {
             then
               CONSUL_HTTP_TOKEN="$(< ${hashiTokens.consul-default})"
               export CONSUL_HTTP_TOKEN
-            # Therefore, on core nodes, use the sops out-of-band bootstrapped master token
+            # Therefore, on core nodes, use the out-of-band bootstrapped master token
             elif [ -s ${gossipEncryptionMaterial.consul} ]
             then
               # as of writing: core nodes are observed to posess the master token
@@ -485,7 +498,7 @@ in {
 
             set -x
             cd /var/lib/consul/
-            cp /etc/ssl/certs/cert-key.pem .
+            cp ${certKeyFile} cert-key.pem
             chown --reference . --recursive .
             consul reload
           '';

--- a/modules/ingress-config.nix
+++ b/modules/ingress-config.nix
@@ -1,4 +1,8 @@
-{ pkgs, config, lib, pkiFiles, hashiTokens, letsencryptCertMaterial, ... }: {
+{ pkgs, config, lib, pkiFiles, hashiTokens, letsencryptCertMaterial, ... }:
+let
+  deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
+  consulCoreNode = builtins.head config.services.consul.serverNodeNames;
+in {
   options = {
     services.ingress-config = {
       enable = lib.mkEnableOption "Enable Ingress configuration generation";
@@ -87,7 +91,7 @@
         balance roundrobin
 
       resolvers consul
-        nameserver dnsmasq ${config.cluster.coreNodes.core-1.privateIP}:53
+        nameserver dnsmasq ${config.cluster.coreNodes.${consulCoreNode}.privateIP}:53
         accepted_payload_size 8192
         hold valid 5s
 

--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -697,9 +697,10 @@ let
         privateIP = lib.mkOption { type = with lib.types; str; };
 
         # flake = lib.mkOption { type = with lib.types; str; };
+
         datacenter = lib.mkOption {
           type = with lib.types; str;
-          default = this.config.region;
+          default = if this.config.deployType == "aws" then (kms2region cfg.kms) else "dc1";
         };
 
         subnet = lib.mkOption {

--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -208,6 +208,11 @@ let
           default = { };
         };
 
+        premSimNodes = lib.mkOption {
+          type = with lib.types; attrsOf coreNodeType;
+          default = { };
+        };
+
         awsAutoScalingGroups = lib.mkOption {
           type = with lib.types; attrsOf awsAutoScalingGroupType;
           default = { };
@@ -291,6 +296,19 @@ let
               core-1.cidr = "172.16.0.0/24";
               core-2.cidr = "172.16.1.0/24";
               core-3.cidr = "172.16.2.0/24";
+            };
+          };
+        };
+
+        premSimVpc = lib.mkOption {
+          type = with lib.types; vpcType "${cfg.name}-premSim";
+          default = {
+            inherit (cfg) region;
+
+            cidr = "10.255.0.0/16";
+
+            subnets = {
+              premSim.cidr = "10.255.0.0/24";
             };
           };
         };
@@ -617,6 +635,15 @@ let
           default = [ ];
         };
 
+        node_class = lib.mkOption {
+          type = with lib.types; str;
+        };
+
+        deployType = lib.mkOption {
+          type = with lib.types; enum [ "aws" "prem" "premSim" ];
+          default = "aws";
+        };
+
         ami = lib.mkOption {
           type = with lib.types; str;
           default = config.cluster.ami;
@@ -670,6 +697,10 @@ let
         privateIP = lib.mkOption { type = with lib.types; str; };
 
         # flake = lib.mkOption { type = with lib.types; str; };
+        datacenter = lib.mkOption {
+          type = with lib.types; str;
+          default = this.config.region;
+        };
 
         subnet = lib.mkOption {
           type = with lib.types; subnetType;
@@ -751,6 +782,11 @@ let
         modules = lib.mkOption {
           type = with lib.types; listOf (oneOf [ path attrs ]);
           default = [ ];
+        };
+
+        deployType = lib.mkOption {
+          type = with lib.types; enum [ "aws" "prem" "premSim" ];
+          default = "aws";
         };
 
         ami = lib.mkOption {
@@ -870,7 +906,7 @@ in {
     currentCoreNode = lib.mkOption {
       internal = true;
       type = with lib.types; nullOr attrs;
-      default = cfg.coreNodes."${nodeName}" or null;
+      default = cfg.coreNodes."${nodeName}" or cfg.premSimNodes."${nodeName}" or null;
     };
 
     currentAwsAutoScalingGroup = lib.mkOption {

--- a/modules/terraform/prem_sim.nix
+++ b/modules/terraform/prem_sim.nix
@@ -1,0 +1,224 @@
+{ self, lib, pkgs, config, terralib, ... }:
+let
+  inherit (terralib)
+    var id pp regions awsProviderNameFor awsProviderFor mkSecurityGroupRule
+    nullRoute;
+
+  merge = lib.foldl' lib.recursiveUpdate { };
+  tags = { Cluster = config.cluster.name; };
+in {
+  tf.prem-sim.configuration = {
+    terraform.backend.http = let
+      vbk =
+        "https://vbk.infra.aws.iohkdev.io/state/${config.cluster.name}/prem-sim";
+    in {
+      address = vbk;
+      lock_address = vbk;
+      unlock_address = vbk;
+    };
+
+    terraform.required_providers = pkgs.terraform-provider-versions;
+
+    provider = {
+      acme = { server_url = "https://acme-v02.api.letsencrypt.org/directory"; };
+
+      aws = [{ inherit (config.cluster) region; }] ++ (lib.forEach regions
+        (region: {
+          inherit region;
+          alias = awsProviderNameFor region;
+        }));
+    };
+
+    # ---------------------------------------------------------------
+    # Networking
+    # ---------------------------------------------------------------
+
+    resource.aws_vpc.prem_sim = {
+      provider = awsProviderFor config.cluster.region;
+      lifecycle = [{ create_before_destroy = true; }];
+
+      cidr_block = config.cluster.premSimVpc.cidr;
+      enable_dns_hostnames = true;
+      tags = {
+        Cluster = config.cluster.name;
+        Name = config.cluster.premSimVpc.name;
+        Region = config.cluster.region;
+      };
+    };
+
+    resource.aws_internet_gateway."${config.cluster.name}-premSim" = {
+      lifecycle = [{ create_before_destroy = true; }];
+
+      vpc_id = id "aws_vpc.prem_sim";
+      tags = {
+        Cluster = config.cluster.name;
+        Name = "${config.cluster.name}-premSim";
+      };
+    };
+
+    resource.aws_route_table."${config.cluster.name}-premSim" = {
+      vpc_id = id "aws_vpc.prem_sim";
+      lifecycle = [{ create_before_destroy = true; }];
+
+      tags = {
+        Cluster = config.cluster.name;
+        Name = "${config.cluster.name}-premSim";
+      };
+    };
+
+    resource.aws_route.prem_sim = nullRoute // {
+      route_table_id = id "aws_route_table.${config.cluster.name}-premSim";
+      destination_cidr_block = "0.0.0.0/0";
+      gateway_id = id "aws_internet_gateway.${config.cluster.name}-premSim";
+    };
+
+    resource.aws_subnet = lib.flip lib.mapAttrs' config.cluster.premSimVpc.subnets
+      (name: subnet:
+        lib.nameValuePair subnet.name {
+          provider = awsProviderFor config.cluster.vpc.region;
+          vpc_id = id "aws_vpc.prem_sim";
+          cidr_block = subnet.cidr;
+
+          lifecycle = [{ create_before_destroy = true; }];
+
+          tags = {
+            Cluster = config.cluster.name;
+            Name = subnet.name;
+          };
+        });
+
+    resource.aws_route_table_association = lib.mapAttrs' (name: subnet:
+      lib.nameValuePair "${config.cluster.name}-${name}-internet" {
+        subnet_id = subnet.id;
+        route_table_id = id "aws_route_table.${config.cluster.name}-premSim";
+      }) config.cluster.premSimVpc.subnets;
+
+    # ---------------------------------------------------------------
+    # SSL/TLS - root ssh
+    # ---------------------------------------------------------------
+
+    # Prem simulated nodes share a keypair with aws cloud nodes
+    resource.aws_key_pair.prem_sim = lib.mkIf (config.cluster.generateSSHKey) {
+      provider = awsProviderFor config.cluster.region;
+      key_name = "${config.cluster.name}-premSim";
+      public_key = var ''file("secrets/ssh-${config.cluster.name}.pub")'';
+    };
+
+    # ---------------------------------------------------------------
+    # Prem Simulation Instance IAM + Security Group
+    # ---------------------------------------------------------------
+
+    resource.aws_security_group = {
+      "${config.cluster.name}-premSim" = {
+        provider = awsProviderFor config.cluster.region;
+        name_prefix = "${config.cluster.name}-premSim";
+        description =
+          "Security group for Simulated Premise Nodes in ${config.cluster.name}-premSim";
+        vpc_id = id "aws_vpc.prem_sim";
+        lifecycle = [{ create_before_destroy = true; }];
+      };
+    };
+
+    resource.aws_security_group_rule = let
+      mapPremInstances = _: premSimNode:
+        merge (lib.flip lib.mapAttrsToList premSimNode.securityGroupRules
+          (_: rule:
+            lib.listToAttrs (lib.flatten (lib.flip map rule.protocols (protocol:
+              mkSecurityGroupRule {
+                prefix = "${config.cluster.name}-premSim";
+                inherit (config.cluster) region;
+                inherit rule protocol;
+              })))));
+
+      premSimNodes' =
+        lib.mapAttrsToList mapPremInstances config.cluster.premSimNodes;
+    in merge premSimNodes';
+
+    # ---------------------------------------------------------------
+    # Prem Sim Nodes
+    # ---------------------------------------------------------------
+
+    resource.aws_eip = lib.mapAttrs' (name: premSimNode:
+      lib.nameValuePair premSimNode.uid {
+        vpc = true;
+        network_interface = id "aws_network_interface.${premSimNode.uid}";
+        associate_with_private_ip = premSimNode.privateIP;
+        tags = {
+          Cluster = config.cluster.name;
+          Name = premSimNode.name;
+        };
+        lifecycle = [{ create_before_destroy = true; }];
+      }) config.cluster.premSimNodes;
+
+    resource.aws_network_interface = lib.mapAttrs' (name: premSimNode:
+      lib.nameValuePair premSimNode.uid {
+        subnet_id = premSimNode.subnet.id;
+        security_groups = [ premSimNode.securityGroupId ];
+        private_ips = [ premSimNode.privateIP ];
+        tags = {
+          Cluster = config.cluster.name;
+          Name = premSimNode.name;
+        };
+        lifecycle = [{ create_before_destroy = true; }];
+      }) config.cluster.premSimNodes;
+
+    resource.aws_instance = lib.mapAttrs (name: premSimNode:
+      lib.mkMerge [
+        (lib.mkIf premSimNode.enable {
+          inherit (premSimNode) ami;
+          instance_type = premSimNode.instanceType;
+          monitoring = true;
+
+          tags = {
+            Cluster = config.cluster.name;
+            Name = name;
+            UID = premSimNode.uid;
+            premSimulation = "true";
+            # Flake = premSimNode.flake;
+          } // premSimNode.tags;
+
+          root_block_device = {
+            volume_type = "gp2";
+            volume_size = premSimNode.volumeSize;
+            delete_on_termination = true;
+          };
+
+          # iam_instance_profile = premSimNode.iam.instanceProfile.tfName;
+
+          network_interface = {
+            network_interface_id = id "aws_network_interface.${premSimNode.uid}";
+            device_index = 0;
+          };
+
+          user_data = premSimNode.userData;
+
+          ebs_optimized =
+            lib.mkIf (premSimNode.ebsOptimized != null) premSimNode.ebsOptimized;
+
+          provisioner = [
+            {
+              local-exec = {
+                command = "${
+                    self.nixosConfigurations."${config.cluster.name}-${name}".config.secrets.generateScript
+                  }/bin/generate-secrets";
+              };
+            }
+            {
+              local-exec = let
+                command =
+                  premSimNode.localProvisioner.protoCommand (var "self.public_ip");
+              in {
+                inherit command;
+                inherit (premSimNode.localProvisioner) interpreter environment;
+                working_dir = premSimNode.localProvisioner.workingDir;
+              };
+            }
+          ];
+        })
+
+        (lib.mkIf config.cluster.generateSSHKey {
+          key_name = "${config.cluster.name}-premSim";
+        })
+      ]) config.cluster.premSimNodes;
+  };
+}

--- a/modules/vault-agent.nix
+++ b/modules/vault-agent.nix
@@ -2,6 +2,8 @@
 let
   cfg = config.services.vault-agent;
 
+  deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
+
   templateType = with lib.types;
     submodule ({ name, ... }: {
       options = {
@@ -59,7 +61,7 @@ in {
 
     autoAuthMethod = lib.mkOption {
       type = with lib.types; enum [ "aws" "cert" ];
-      default = "aws";
+      default = if deployType == "aws" then "aws" else "cert";
     };
 
     autoAuthConfig = lib.mkOption {

--- a/modules/vault-policies.nix
+++ b/modules/vault-policies.nix
@@ -92,10 +92,10 @@ in {
         set -euo pipefail
 
         ${if (deployType == "aws") then ''
-          VAULT_TOKEN="$(sops -d --extract '["root_token"]' vault.enc.json)"
-        '' else ''
-          VAULT_TOKEN="$(rage -i /etc/ssh/ssh_host_ed25519_key -d /var/lib/vault/vault-bootstrap.json.age | jq -r '.root_token')"
-        ''}
+          VAULT_TOKEN="$(sops -d --extract '["root_token"]' vault.enc.json)"''
+        else ''
+          VAULT_TOKEN="$(rage -i /etc/ssh/ssh_host_ed25519_key -d /var/lib/vault/vault-bootstrap.json.age | jq -r '.root_token')"''
+        }
 
         export VAULT_TOKEN
         export VAULT_ADDR=https://127.0.0.1:8200

--- a/modules/vault-policies.nix
+++ b/modules/vault-policies.nix
@@ -1,5 +1,7 @@
 { pkgs, lib, config, bittelib, ... }:
 let
+  deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
+
   rmModules = arg:
     let
       sanitized = lib.mapAttrsToList (name: value:
@@ -79,15 +81,22 @@ in {
 
       environment = {
         inherit (config.environment.variables)
-          AWS_DEFAULT_REGION VAULT_CACERT VAULT_ADDR VAULT_FORMAT NOMAD_ADDR;
+          VAULT_CACERT VAULT_ADDR VAULT_FORMAT NOMAD_ADDR;
+        AWS_DEFAULT_REGION = lib.mkIf (deployType == "aws")
+                             config.environment.variables.AWS_DEFAULT_REGION;
       };
 
-      path = with pkgs; [ vault-bin sops jq nomad curl cacert ];
+      path = with pkgs; [ vault-bin sops rage jq nomad curl cacert ];
 
       script = ''
         set -euo pipefail
 
-        VAULT_TOKEN="$(sops -d --extract '["root_token"]' vault.enc.json)"
+        ${if (deployType == "aws") then ''
+          VAULT_TOKEN="$(sops -d --extract '["root_token"]' vault.enc.json)"
+        '' else ''
+          VAULT_TOKEN="$(rage -i /etc/ssh/ssh_host_ed25519_key -d /var/lib/vault/vault-bootstrap.json.age | jq -r '.root_token')"
+        ''}
+
         export VAULT_TOKEN
         export VAULT_ADDR=https://127.0.0.1:8200
 

--- a/modules/vault.nix
+++ b/modules/vault.nix
@@ -420,10 +420,10 @@ in {
         set -exuo pipefail
 
         ${if deployType == "aws" then ''
-          ip="$(curl -f -s http://169.254.169.254/latest/meta-data/local-ipv4)"
-        '' else ''
-          ip="$(ip -j addr | jq -r '.[] | select(.operstate == "UP") | .addr_info[] | select(.family == "inet") | .local')"
-        ''}
+          ip="$(curl -f -s http://169.254.169.254/latest/meta-data/local-ipv4)"''
+        else ''
+          ip="$(ip -j addr | jq -r '.[] | select(.operstate == "UP") | .addr_info[] | select(.family == "inet") | .local')"''
+        }
 
         addr="https://$ip"
         echo '{"cluster_addr": "'"$addr:8201"'", "api_addr": "'"$addr:8200"'"}' \

--- a/modules/vault.nix
+++ b/modules/vault.nix
@@ -1,5 +1,6 @@
-{ lib, config, pkgs, nodeName, bittelib, hashiTokens, gossipEncryptionMaterial, ... }:
+{ lib, config, pkgs, nodeName, bittelib, hashiTokens, gossipEncryptionMaterial, pkiFiles, ... }:
 let
+  deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
   sanitize = obj:
     lib.getAttr (builtins.typeOf obj) {
       bool = obj;
@@ -119,6 +120,12 @@ in {
       default = "vault.d";
     };
 
+    serverNodeNames = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = if deployType == "aws" then [ "core-1" "core-2" "core-3" ]
+                else [ "prem-1" "prem-2" "prem-3" ];
+    };
+
     extraConfig = lib.mkOption {
       type = with lib.types; attrs;
       default = { };
@@ -204,21 +211,20 @@ in {
     };
 
     seal = lib.mkOption {
-      type = with lib.types;
-        submodule {
-          options = {
-            awskms = lib.mkOption {
-              type = with lib.types;
-                submodule {
-                  options = {
-                    kmsKeyId = lib.mkOption { type = with lib.types; str; };
-                    region = lib.mkOption { type = with lib.types; str; };
-                  };
-                };
-            };
+      type = with lib.types; nullOr (submodule {
+        options = {
+          awskms = lib.mkOption {
+            type = with lib.types; nullOr (submodule {
+              options = {
+                kmsKeyId = lib.mkOption { type = with lib.types; str; };
+                region = lib.mkOption { type = with lib.types; str; };
+              };
+            });
+            default = null;
           };
         };
-      default = { };
+      });
+      default = null;
     };
 
     serviceRegistration = lib.mkOption {
@@ -309,10 +315,15 @@ in {
       };
 
       serviceConfig = let
+        certChainFile = if deployType == "aws" then pkiFiles.certChainFile
+                      else pkiFiles.serverCertChainFile;
+        certKeyFile = if deployType == "aws" then pkiFiles.keyFile
+                      else pkiFiles.serverKeyFile;
         preScript = pkgs.writeBashBinChecked "vault-start-pre" ''
           export PATH="${lib.makeBinPath [ pkgs.coreutils ]}"
           set -exuo pipefail
-          cp /etc/ssl/certs/cert-key.pem .
+          cp ${certChainFile} full.pem
+          cp ${certKeyFile} cert-key.pem
           chown --reference . --recursive .
         '';
 
@@ -392,7 +403,7 @@ in {
         '';
       };
 
-    systemd.services.vault-aws-addr = {
+    systemd.services.vault-addr = {
       wantedBy = [ "vault.service" ];
       before = [ "vault.service" ];
 
@@ -403,12 +414,17 @@ in {
         RestartSec = "20s";
       };
 
-      path = with pkgs; [ curl jq ];
+      path = with pkgs; [ curl jq iproute2 ];
 
       script = ''
         set -exuo pipefail
 
-        ip="$(curl -f -s http://169.254.169.254/latest/meta-data/local-ipv4)"
+        ${if deployType == "aws" then ''
+          ip="$(curl -f -s http://169.254.169.254/latest/meta-data/local-ipv4)"
+        '' else ''
+          ip="$(ip -j addr | jq -r '.[] | select(.operstate == "UP") | .addr_info[] | select(.family == "inet") | .local')"
+        ''}
+
         addr="https://$ip"
         echo '{"cluster_addr": "'"$addr:8201"'", "api_addr": "'"$addr:8200"'"}' \
         | jq -S . \

--- a/overlay.nix
+++ b/overlay.nix
@@ -14,6 +14,11 @@ rec {
   nixUnstable = final.nix;
 
   nomad = inputs.nomad.defaultPackage."${final.system}";
+
+  # Until ops Rakefile is rewritten for ragenix nix secrets vs. toml
+  inherit (inputs.agenix.packages."${final.system}") agenix;
+  inherit (inputs.agenix-cli.packages."${final.system}") agenix-cli;
+
   ragenix = inputs.ragenix.defaultPackage."${final.system}";
 
   # bitte-ruby and bundler for prem, premSim ops repo Rakefile support

--- a/overlay.nix
+++ b/overlay.nix
@@ -16,6 +16,18 @@ rec {
   nomad = inputs.nomad.defaultPackage."${final.system}";
   ragenix = inputs.ragenix.defaultPackage."${final.system}";
 
+  # bitte-ruby and bundler for prem, premSim ops repo Rakefile support
+  bitte-ruby = inputs.nixpkgs-auxiliary.legacyPackages.${final.system}.bundlerEnv {
+    name = "bitte-gems";
+    gemdir = ./.;
+  };
+
+  bundler = inputs.nixpkgs-auxiliary.legacyPackages.${final.system}.bundler.overrideAttrs (o: {
+    postInstall = ''
+      sed -i -e '/if sudo_needed/I,+2 d' $out/${prev.ruby.gemPath}/gems/${o.gemName}-${o.version}/lib/bundler.rb
+    '';
+  });
+
   ssh-keys = let
     keys = import (ops-lib + "/overlays/ssh-keys.nix") lib;
     inherit (keys) allKeysFrom devOps;

--- a/profiles/auxiliaries/oauth.nix
+++ b/profiles/auxiliaries/oauth.nix
@@ -1,25 +1,33 @@
-{ config, lib, pkgs, ... }: {
+{ config, lib, pkgs, ... }:
+let
+  deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
+  domain = config.${if deployType == "aws" then "cluster" else "currentCoreNode"}.domain;
+  isSops = deployType == "aws";
+in {
 
   services.oauth2_proxy.enable = true;
 
   services.oauth2_proxy = {
-    extraConfig.whitelist-domain = ".${config.cluster.domain}";
+    extraConfig.whitelist-domain = ".${domain}";
     # extraConfig.github-org = "input-output-hk";
     # extraConfig.github-repo = "input-output-hk/mantis-ops";
     # extraConfig.github-user = "manveru,johnalotoski";
     extraConfig.pass-user-headers = "true";
     extraConfig.set-xauthrequest = "true";
     extraConfig.reverse-proxy = "true";
+    extraConfig.skip-provider-button = lib.mkDefault "true";
+    extraConfig.upstream = lib.mkDefault "static://202";
+
     provider = "google";
     keyFile = "/run/keys/oauth-secrets";
 
     email.domains = [ "iohk.io" ];
-    cookie.domain = ".${config.cluster.domain}";
+    cookie.domain = ".${domain}";
   };
 
   users.extraGroups.keys.members = [ "oauth2_proxy" ];
 
-  secrets.install.oauth.script = ''
+  secrets.install.oauth.script = lib.mkIf isSops ''
     export PATH="${lib.makeBinPath (with pkgs; [ sops coreutils ])}"
 
     cat ${(toString config.secrets.encryptedRoot) + "/oauth-secrets"} \
@@ -30,6 +38,18 @@
     chmod g+r /run/keys/oauth-secrets
   '';
 
-  systemd.services.oauth2_proxy.after = [ "secret-oauth.service" ];
-  systemd.services.oauth2_proxy.wants = [ "secret-oauth.service" ];
+  systemd.services.oauth2_proxy = lib.mkIf isSops {
+    after = [ "secret-oauth.service" ];
+    wants = [ "secret-oauth.service" ];
+  };
+
+  age.secrets = lib.mkIf (!isSops) {
+    oauth-password = {
+      file = config.age.encryptedRoot + "/oauth/password.age";
+      path = "/run/keys/oauth-secrets";
+      owner = "root";
+      group = "keys";
+      mode = "0644";
+    };
+  };
 }

--- a/profiles/bootstrap/default.nix
+++ b/profiles/bootstrap/default.nix
@@ -9,7 +9,7 @@ let
   exportVaultRoot = if (deployType == "aws") then ''
     set +x
     VAULT_TOKEN="$(
-      sops -d --extract '["root_token"]' /var/lib/vault.enc.json
+      sops -d --extract '["root_token"]' /var/lib/vault/vault.enc.json
     )"
     export VAULT_TOKEN
     set -x
@@ -416,8 +416,8 @@ in {
             else
               echo "Couldnt't bootstrap, something went fatally wrong!"
               exit 1
-            fi
-          '' else ''
+            fi''
+          else ''
             vault operator init > /var/lib/vault/vault-bootstrap.json
             readarray -t unseal_keys < <(jq < /var/lib/vault/vault-bootstrap.json -e -r '.unseal_keys_b64[0,1,2]')
 
@@ -450,8 +450,8 @@ in {
               echo "Couldnt't bootstrap, something went fatally wrong!"
               exit 1
             fi
-            set -x
-          ''}
+            set -x''
+          }
         fi
 
         ${exportVaultRoot}
@@ -463,8 +463,8 @@ in {
         secrets="$(vault secrets list)"
 
         ${lib.optionalString (deployType == "aws") ''
-          echo "$secrets" | jq -e '."aws/"'       || vault secrets enable aws
-        ''}
+          echo "$secrets" | jq -e '."aws/"'       || vault secrets enable aws''
+        }
 
         echo "$secrets" | jq -e '."consul/"'      || vault secrets enable consul
         echo "$secrets" | jq -e '."kv/"'          || vault secrets enable -version=2 kv
@@ -475,8 +475,8 @@ in {
         auth="$(vault auth list)"
 
         ${lib.optionalString (deployType == "aws") ''
-          echo "$auth" | jq -e '."aws/"'          || vault auth enable aws
-        ''}
+          echo "$auth" | jq -e '."aws/"'          || vault auth enable aws''
+        }
 
         ${lib.optionalString (deployType != "aws") ''
           echo "$auth" | jq -e '."cert/"'         || vault auth enable cert
@@ -491,8 +491,8 @@ in {
             display_name=vault-agent-client \
             policies=vault-agent-client \
             certificate=@"/etc/ssl/certs/client.pem" \
-            ttl=3600
-        ''}
+            ttl=3600''
+        }
 
         # This lets Vault issue Consul tokens
 
@@ -515,11 +515,11 @@ in {
           pki/config/urls \
           ${if deployType != "premSim" then ''
             issuing_certificates="https://vault.${config.cluster.domain}:8200/v1/pki/ca" \
-            crl_distribution_points="https://vault.${config.cluster.domain}:8200/v1/pki/crl"
-          '' else ''
+            crl_distribution_points="https://vault.${config.cluster.domain}:8200/v1/pki/crl"''
+          else ''
             issuing_certificates="https://vault.${premSimDomain}:8200/v1/pki/ca" \
-            crl_distribution_points="https://vault.${premSimDomain}:8200/v1/pki/crl"
-          ''}
+            crl_distribution_points="https://vault.${premSimDomain}:8200/v1/pki/crl"''
+          }
 
         vault write \
           pki/roles/server \
@@ -535,10 +535,10 @@ in {
           key_type=ec \
           key_bits=256 \
           ${if deployType == "aws" then ''
-            allowed_domains=service.consul,${config.cluster.region}.consul \
-          '' else ''
-            allowed_domains=service.consul,${datacenter}.consul \
-          ''}
+            allowed_domains=service.consul,${config.cluster.region}.consul \''
+          else ''
+            allowed_domains=service.consul,${datacenter}.consul \''
+          }
           allow_subdomains=true \
           generate_lease=true \
           max_ttl=223h

--- a/profiles/bootstrap/default.nix
+++ b/profiles/bootstrap/default.nix
@@ -1,18 +1,37 @@
-{ lib, pkgs, config, bittelib, pkiFiles, hashiTokens, gossipEncryptionMaterial, ... }:
+{ lib, pkgs, config, bittelib, pkiFiles, hashiTokens, gossipEncryptionMaterial, nodeName, ... }:
 
 let
+  inherit (config.currentCoreNode) datacenter deployType privateIP;
+
   cfg = config.services.bootstrap;
+  premSimDomain = config.currentCoreNode.domain;
+
+  exportVaultRoot = if (deployType == "aws") then ''
+    set +x
+    VAULT_TOKEN="$(
+      sops -d --extract '["root_token"]' /var/lib/vault.enc.json
+    )"
+    export VAULT_TOKEN
+    set -x
+  '' else ''
+    set +x
+    VAULT_TOKEN="$(
+      rage -i /etc/ssh/ssh_host_ed25519_key -d /var/lib/vault/vault-bootstrap.json.age | jq -r '.root_token'
+    )"
+    export VAULT_TOKEN
+    set -x
+  '';
 
   exportConsulMaster = ''
     set +x
     CONSUL_HTTP_TOKEN="$(
-      ${pkgs.jq}/bin/jq -e -r '.acl.tokens.master' < ${gossipEncryptionMaterial.consul}
+      jq -e -r '.acl.tokens.master' < ${gossipEncryptionMaterial.consul}
     )"
     export CONSUL_HTTP_TOKEN
     set -x
   '';
 
-  initialVaultSecrets = ''
+  initialVaultSecrets = if deployType == "aws" then ''
     sops --decrypt --extract '["encrypt"]' ${
       (toString config.secrets.encryptedRoot) + "/consul-clients.json"
     } | vault kv put kv/bootstrap/clients/consul encrypt=-
@@ -24,6 +43,24 @@ let
     sops --decrypt ${
       (toString config.secrets.encryptedRoot) + "/nix-cache.json"
     } | vault kv put kv/bootstrap/cache/nix-key -
+  '' else ''
+    rage -i /etc/ssh/ssh_host_ed25519_key -d ${(toString config.age.encryptedRoot) + "/consul/encrypt.age"} \
+      | tr -d '\n' | vault kv put kv/bootstrap/clients/consul encrypt=-
+    rage -i /etc/ssh/ssh_host_ed25519_key -d ${(toString config.age.encryptedRoot) + "/nomad/encrypt.age"} \
+      | tr -d '\n' | vault kv put kv/bootstrap/clients/nomad encrypt=-
+    set +x
+    NIX_KEY_SECRET="$(
+      rage -i /etc/ssh/ssh_host_ed25519_key -d ${(toString config.age.encryptedRoot) + "/nix/key.age"}
+    )"
+    NIX_KEY_PUBLIC="$(cat ${(toString config.age.encryptedRoot) + "/nix/key.pub"})"
+    echo '{}' \
+    | jq \
+      -S \
+      --arg NIX_KEY_SECRET "$NIX_KEY_SECRET" \
+      --arg NIX_KEY_PUBLIC "$NIX_KEY_PUBLIC" \
+      '{ private: $NIX_KEY_SECRET, public: $NIX_KEY_PUBLIC }' \
+    | vault kv put kv/bootstrap/cache/nix-key -
+    set -x
   '';
 
   initialVaultStaticSecrets = let
@@ -160,7 +197,7 @@ in {
           AWS_DEFAULT_REGION VAULT_CACERT VAULT_FORMAT VAULT_ADDR;
       };
 
-      path = with pkgs; [ sops vault-bin consul nomad coreutils jq curl ];
+      path = with pkgs; [ sops rage vault-bin consul nomad coreutils jq curl ];
 
       script = let
         consulPolicies =
@@ -180,46 +217,46 @@ in {
 
         pushd /var/lib/vault
 
-        set +x
-        VAULT_TOKEN="$(sops -d --extract '["root_token"]' vault.enc.json)"
-        export VAULT_TOKEN
-        set -x
+        ${exportVaultRoot}
+        ${exportConsulMaster}
 
         ${lib.concatStringsSep "\n" consulPolicies}
 
         vault write /auth/token/roles/nomad-cluster @${nomadClusterRole}
 
-        # Finally allow IAM roles to login to Vault
+        ${lib.optionalString (deployType == "aws") ''
+          # Finally allow IAM roles to login to Vault
 
-        arn="$(
-          curl -f -s http://169.254.169.254/latest/meta-data/iam/info \
-          | jq -e -r .InstanceProfileArn \
-          | sed 's/:instance.*//'
-        )"
+          arn="$(
+            curl -f -s http://169.254.169.254/latest/meta-data/iam/info \
+            | jq -e -r .InstanceProfileArn \
+            | sed 's/:instance.*//'
+          )"
 
-        vault write auth/aws/role/core-iam \
-          auth_type=iam \
-          bound_iam_principal_arn="$arn:role/${config.cluster.name}-core" \
-          policies=default,core,nomad-server
-
-        vault write auth/aws/role/${config.cluster.name}-core \
-          auth_type=iam \
-          bound_iam_principal_arn="$arn:role/${config.cluster.name}-core" \
-          policies=default,core,nomad-server
-
-        vault write auth/aws/role/${config.cluster.name}-client \
-          auth_type=iam \
-          bound_iam_principal_arn="$arn:role/${config.cluster.name}-client" \
-          policies=default,client,nomad-server \
-          period=24h
-
-        ${lib.concatStringsSep "\n" (lib.forEach config.cluster.adminNames (name: ''
-          vault write "auth/aws/role/${name}" \
+          vault write auth/aws/role/core-iam \
             auth_type=iam \
-            bound_iam_principal_arn="$arn:user/${name}" \
-            policies=default,admin \
-            max_ttl=24h
-        ''))}
+            bound_iam_principal_arn="$arn:role/${config.cluster.name}-core" \
+            policies=default,core,nomad-server
+
+          vault write auth/aws/role/${config.cluster.name}-core \
+            auth_type=iam \
+            bound_iam_principal_arn="$arn:role/${config.cluster.name}-core" \
+            policies=default,core,nomad-server
+
+          vault write auth/aws/role/${config.cluster.name}-client \
+            auth_type=iam \
+            bound_iam_principal_arn="$arn:role/${config.cluster.name}-client" \
+            policies=default,client,nomad-server \
+            period=24h
+
+          ${lib.concatStringsSep "\n" (lib.forEach config.cluster.adminNames (name: ''
+            vault write "auth/aws/role/${name}" \
+              auth_type=iam \
+              bound_iam_principal_arn="$arn:user/${name}" \
+              policies=default,admin \
+              max_ttl=24h
+          ''))}
+        ''}
 
         ${initialVaultSecrets}
 
@@ -248,10 +285,10 @@ in {
 
       environment = {
         inherit (config.environment.variables) AWS_DEFAULT_REGION NOMAD_ADDR;
-        CURL_CA_BUNDLE = pkiFiles.caCertFile;
+        CURL_CA_BUNDLE = pkiFiles.certChainFile;
       };
 
-      path = with pkgs; [ curl sops coreutils jq nomad vault-bin gawk ];
+      path = with pkgs; [ curl sops rage coreutils jq nomad vault-bin gawk ];
 
       script = ''
         set -euo pipefail
@@ -276,8 +313,7 @@ in {
         NOMAD_TOKEN="$(< bootstrap.token)"
         export NOMAD_TOKEN
 
-        VAULT_TOKEN="$(sops -d --extract '["root_token"]' /var/lib/vault/vault.enc.json)"
-        export VAULT_TOKEN
+        ${exportVaultRoot}
 
         nomad_vault_token="$(
           nomad acl token create -type management \
@@ -332,11 +368,13 @@ in {
         consul
         vault-bin
         sops
+        rage
         coreutils
         jq
         gnused
         curl
         netcat
+        openssh
       ];
 
       script = ''
@@ -361,35 +399,69 @@ in {
         if vault status | jq -e 'select(.sealed == false)'; then
           echo "Vault already unsealed"
         else
-          vault operator init \
-            -recovery-shares 1 \
-            -recovery-threshold 1 | \
-              sops \
-              --input-type json \
-              --output-type json \
-              --kms "${config.cluster.kms}" \
-              --encrypt \
-              /dev/stdin > vault.enc.json.tmp
+          ${if deployType == "aws" then ''
+            vault operator init \
+              -recovery-shares 1 \
+              -recovery-threshold 1 | \
+                sops \
+                --input-type json \
+                --output-type json \
+                --kms "${config.cluster.kms}" \
+                --encrypt \
+                /dev/stdin > vault.enc.json.tmp
 
-          if [ -s vault.enc.json.tmp ]; then
-            mv vault.enc.json.tmp vault.enc.json
-          else
-            echo "Couldnt't bootstrap, something went fatally wrong!"
-            exit 1
-          fi
+            if [ -s vault.enc.json.tmp ]; then
+              mv vault.enc.json.tmp vault.enc.json
+            else
+              echo "Couldnt't bootstrap, something went fatally wrong!"
+              exit 1
+            fi
+          '' else ''
+            for vault in ${lib.concatStringsSep " " config.services.vault.serverNodeNames}; do
+              echo "Unsealing $vault"
+              for key in "''${unseal_keys[@]}"; do
+                result="${toString (builtins.length config.services.vault.serverNodeNames * 3)}"
+                until [ "$result" -eq 0 ]; do
+                  echo "Unsealing $vault with key"
+                  ssh "$vault" \
+                    -i /etc/ssh/ssh_host_ed25519_key \
+                    -o UserKnownHostsFile=/dev/null \
+                    -o StrictHostKeyChecking=no \
+                    -- 'bash -c "until CHECK=\"$(vault status)\" &> /dev/null; do [[ $? -eq 2 ]] && break; sleep 1; done; until vault status | jq -e \"select(.initialized == true)\"; do sleep 1; done; vault operator unseal "'"$key"
+                  result="$?"
+                  echo "Unsealed $vault with key result: $result"
+                  sleep 1
+                done
+              done
+              echo "Sleeping 10 seconds to allow next vault to initialize..."
+              sleep 10
+            done
+            rage -i /etc/ssh/ssh_host_ed25519_key -a -e /var/lib/vault/vault-bootstrap.json \
+              -o /var/lib/vault/vault-bootstrap.json.age.tmp
+            if [ -s /var/lib/vault/vault-bootstrap.json.age.tmp ]; then
+              rm /var/lib/vault/vault-bootstrap.json
+              [ -s /var/lib/vault/vault-bootstrap.json.age ] && mv /var/lib/vault/vault-bootstrap.json.age /var/lib/vault/vault-bootstrap.json.age-$(date -u +"%F-%T")
+              mv /var/lib/vault/vault-bootstrap.json.age.tmp /var/lib/vault/vault-bootstrap.json.age
+            else
+              echo "Couldnt't bootstrap, something went fatally wrong!"
+              exit 1
+            fi
+            set -x
+          ''}
         fi
 
-        set +x
-        VAULT_TOKEN="$(sops -d --extract '["root_token"]' vault.enc.json)"
-        export VAULT_TOKEN
-
+        ${exportVaultRoot}
         ${exportConsulMaster}
 
+        set -x
         # vault audit enable socket address=127.0.0.1:9090 socket_type=tcp
 
         secrets="$(vault secrets list)"
 
-        echo "$secrets" | jq -e '."aws/"'         || vault secrets enable aws
+        ${lib.optionalString (deployType == "aws") ''
+          echo "$secrets" | jq -e '."aws/"'       || vault secrets enable aws
+        ''}
+
         echo "$secrets" | jq -e '."consul/"'      || vault secrets enable consul
         echo "$secrets" | jq -e '."kv/"'          || vault secrets enable -version=2 kv
         echo "$secrets" | jq -e '."nomad/"'       || vault secrets enable nomad
@@ -398,7 +470,25 @@ in {
 
         auth="$(vault auth list)"
 
-        echo "$auth" | jq -e '."aws/"'     || vault auth enable aws
+        ${lib.optionalString (deployType == "aws") ''
+          echo "$auth" | jq -e '."aws/"'          || vault auth enable aws
+        ''}
+
+        ${lib.optionalString (deployType != "aws") ''
+          echo "$auth" | jq -e '."cert/"'         || vault auth enable cert
+
+          vault write auth/cert/certs/vault-agent-core \
+            display_name=vault-agent-core \
+            policies=vault-agent-core \
+            certificate=@"/etc/ssl/certs/client.pem" \
+            ttl=3600
+
+          vault write auth/cert/certs/vault-agent-client \
+            display_name=vault-agent-client \
+            policies=vault-agent-client \
+            certificate=@"/etc/ssl/certs/client.pem" \
+            ttl=3600
+        ''}
 
         # This lets Vault issue Consul tokens
 
@@ -419,8 +509,13 @@ in {
 
         vault write \
           pki/config/urls \
-          issuing_certificates="https://vault.${config.cluster.domain}:8200/v1/pki/ca" \
-          crl_distribution_points="https://vault.${config.cluster.domain}:8200/v1/pki/crl"
+          ${if deployType != "premSim" then ''
+            issuing_certificates="https://vault.${config.cluster.domain}:8200/v1/pki/ca" \
+            crl_distribution_points="https://vault.${config.cluster.domain}:8200/v1/pki/crl"
+          '' else ''
+            issuing_certificates="https://vault.${premSimDomain}:8200/v1/pki/ca" \
+            crl_distribution_points="https://vault.${premSimDomain}:8200/v1/pki/crl"
+          ''}
 
         vault write \
           pki/roles/server \
@@ -435,7 +530,11 @@ in {
           pki/roles/client \
           key_type=ec \
           key_bits=256 \
-          allowed_domains=service.consul,${config.cluster.region}.consul \
+          ${if deployType == "aws" then ''
+            allowed_domains=service.consul,${config.cluster.region}.consul \
+          '' else ''
+            allowed_domains=service.consul,${datacenter}.consul \
+          ''}
           allow_subdomains=true \
           generate_lease=true \
           max_ttl=223h

--- a/profiles/client.nix
+++ b/profiles/client.nix
@@ -6,7 +6,7 @@ in {
   imports = [
     ./common.nix
     ./consul/client.nix
-    # ./nomad/client.nix
+    ./nomad/client.nix
     ./vault/client.nix
 
     ./auxiliaries/docker.nix

--- a/profiles/client.nix
+++ b/profiles/client.nix
@@ -1,9 +1,12 @@
-{ self, pkgs, config, lib, ... }: {
+{ self, pkgs, config, lib, nodeName, ... }:
+let
+  deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
+in {
 
   imports = [
     ./common.nix
     ./consul/client.nix
-    ./nomad/client.nix
+    # ./nomad/client.nix
     ./vault/client.nix
 
     ./auxiliaries/docker.nix
@@ -11,8 +14,8 @@
     ./auxiliaries/builder.nix
   ];
 
-  services.s3-upload-flake.enable = true;
-  services.zfs-client-options.enable = true;
+  services.s3-upload-flake.enable = deployType == "aws";
+  services.zfs-client-options.enable = deployType == "aws";
 
   services.telegraf.extraConfig.global_tags.role = "consul-client";
 
@@ -20,5 +23,9 @@
 
   time.timeZone = "UTC";
 
-  networking = { hostId = "9474d585"; };
+  # Maintain backward compat for the aws machines otherwise derive from hostname
+  networking.hostId = if (deployType == "aws") then "9474d585"
+    else (lib.fileContents (pkgs.runCommand "hostId" { } ''
+    ${pkgs.ruby}/bin/ruby -rzlib -e 'File.write(ENV["out"], "%08x" % Zlib.crc32("${nodeName}"))'
+  ''));
 }

--- a/profiles/consul/common.nix
+++ b/profiles/consul/common.nix
@@ -44,7 +44,7 @@
         region = lib.mkIf (deployType != "prem") config.cluster.region;
       } // (lib.optionalAttrs ((config.currentCoreNode or null) != null) {
         inherit (config.currentCoreNode) domain;
-        region = lib.mkIf (deployType != "prem") config.currentCoreNode.instanceType;
+        instance_type = lib.mkIf (deployType != "prem") config.currentCoreNode.instanceType;
       });
 
       # generate deterministic UUIDs for each node so they can rejoin.
@@ -83,19 +83,19 @@
         # Redirect consul and ec2 internal specific queries to their respective upstream DNS servers
         server=/consul/127.0.0.1#8600
         ${lib.optionalString (deployType != "prem") ''
-          server=/internal/169.254.169.253#53
-        ''}
+          server=/internal/169.254.169.253#53''
+        }
 
         # Configure reverse in-addr.arpa DNS lookups to consul for ASGs and core datacenter default address ranges
         ${lib.optionalString (deployType != "prem") ''
           rev-server=10.0.0.0/8,127.0.0.1#8600
-          rev-server=172.16.0.0/16,127.0.0.1#8600
-        ''}
+          rev-server=172.16.0.0/16,127.0.0.1#8600''
+        }
 
         # Define upstream DNS servers
         ${lib.optionalString (deployType != "prem") ''
-        server=169.254.169.253
-        ''}
+          server=169.254.169.253''
+        }
         server=8.8.8.8
 
         # Set cache and security

--- a/profiles/consul/common.nix
+++ b/profiles/consul/common.nix
@@ -8,23 +8,30 @@
     services.dnsmasq.enable = true;
   };
 
-  Config = let ownedKey = "/var/lib/consul/cert-key.pem";
+  Config = let
+    inherit (config.cluster) coreNodes premSimNodes region;
+    deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
+    datacenter = config.currentCoreNode.datacenter or config.currentAwsAutoScalingGroup.datacenter;
+
+    cfg = config.services.consul;
+    ownedChain = "/var/lib/consul/full.pem";
+    ownedKey = "/var/lib/consul/cert-key.pem";
   in {
     services.consul = {
       addresses = { http = lib.mkDefault "127.0.0.1"; };
 
       clientAddr = "0.0.0.0";
-      datacenter = config.cluster.region;
+      datacenter = if deployType == "aws" then region else datacenter;
       enableLocalScriptChecks = true;
       logLevel = "info";
-      primaryDatacenter = config.cluster.region;
+      primaryDatacenter = if deployType == "aws" then region else datacenter;
       tlsMinVersion = "tls12";
       verifyIncoming = true;
       verifyOutgoing = true;
       verifyServerHostname = true;
 
       caFile = pkiFiles.caCertFile;
-      certFile = pkiFiles.certChainFile;
+      certFile = ownedChain;
       keyFile = ownedKey;
 
       telemetry = {
@@ -33,10 +40,11 @@
       };
 
       nodeMeta = {
-        inherit (config.cluster) region;
         inherit nodeName;
+        region = lib.mkIf (deployType != "prem") config.cluster.region;
       } // (lib.optionalAttrs ((config.currentCoreNode or null) != null) {
-        inherit (config.currentCoreNode) instanceType domain;
+        inherit (config.currentCoreNode) domain;
+        region = lib.mkIf (deployType != "prem") config.currentCoreNode.instanceType;
       });
 
       # generate deterministic UUIDs for each node so they can rejoin.
@@ -48,8 +56,10 @@
 
       advertiseAddr = ''{{ GetInterfaceIP "ens5" }}'';
 
-      retryJoin = (lib.mapAttrsToList (_: v: v.privateIP) config.cluster.coreNodes)
-        ++ [ "provider=aws region=${config.cluster.region} tag_key=Consul tag_value=server" ];
+      retryJoin = (lib.mapAttrsToList (_: v: v.privateIP)
+        (lib.filterAttrs (k: v: lib.elem k cfg.serverNodeNames) (premSimNodes // coreNodes)))
+        ++ lib.optionals (deployType == "aws")
+        [ "provider=aws region=${region} tag_key=Consul tag_value=server" ];
 
       connect = {
         caProvider = "consul";
@@ -72,19 +82,27 @@
 
         # Redirect consul and ec2 internal specific queries to their respective upstream DNS servers
         server=/consul/127.0.0.1#8600
-        server=/internal/169.254.169.253#53
+        ${lib.optionalString (deployType != "prem") ''
+          server=/internal/169.254.169.253#53"
+        ''}
 
         # Configure reverse in-addr.arpa DNS lookups to consul for ASGs and core datacenter default address ranges
-        rev-server=10.0.0.0/8,127.0.0.1#8600
-        rev-server=172.16.0.0/16,127.0.0.1#8600
+        ${lib.optionalString (deployType != "prem") ''
+          rev-server=10.0.0.0/8,127.0.0.1#8600
+          rev-server=172.16.0.0/16,127.0.0.1#8600
+        ''}
 
         # Define upstream DNS servers
+        ${lib.optionalString (deployType != "prem") ''
         server=169.254.169.253
+        ''}
         server=8.8.8.8
 
         # Set cache and security
         cache-size=65536
         local-service
+
+        # Append additional extraConfig from the ops repo as needed
       '';
     };
 

--- a/profiles/consul/common.nix
+++ b/profiles/consul/common.nix
@@ -83,7 +83,7 @@
         # Redirect consul and ec2 internal specific queries to their respective upstream DNS servers
         server=/consul/127.0.0.1#8600
         ${lib.optionalString (deployType != "prem") ''
-          server=/internal/169.254.169.253#53"
+          server=/internal/169.254.169.253#53
         ''}
 
         # Configure reverse in-addr.arpa DNS lookups to consul for ASGs and core datacenter default address ranges

--- a/profiles/core-with-spire-server.nix
+++ b/profiles/core-with-spire-server.nix
@@ -1,7 +1,7 @@
 { self, pkgs, config, lib, nodeName, ... }: {
   imports = [ ./core.nix ];
   services = {
-    spire-server.enbale = true;
+    spire-server.enable = true;
     spire-agent.enable = true;
   };
 }

--- a/profiles/core.nix
+++ b/profiles/core.nix
@@ -14,5 +14,5 @@
     consul.enableDebug = false;
   };
 
-  environment.systemPackages = with pkgs; [ sops awscli cfssl tcpdump ];
+  environment.systemPackages = with pkgs; [ sops awscli cfssl tcpdump rage ];
 }

--- a/profiles/monitoring.nix
+++ b/profiles/monitoring.nix
@@ -37,7 +37,7 @@ in {
     domain = "monitoring.${domain}";
     extraOptions = {
       AUTH_PROXY_ENABLED = "true";
-      AUTH_PROXY_HEADER_NAME = "X-Authenticated-User";
+      AUTH_PROXY_HEADER_NAME = "X-Auth-Request-Email";
       AUTH_SIGNOUT_REDIRECT_URL = "/oauth2/sign_out";
       USERS_AUTO_ASSIGN_ORG_ROLE = "Editor";
     };

--- a/profiles/nomad/client.nix
+++ b/profiles/nomad/client.nix
@@ -14,7 +14,7 @@
     services.nomad = {
       client = {
         gc_interval = "12h";
-        node_class = config.${if deployType == "aws" then "currentAwsAutoScalingGroup"}.node_class or "core";
+        node_class = config.${if deployType == "aws" then "currentAwsAutoScalingGroup" else "currentCoreNode"}.node_class or "core";
         chroot_env = {
           # "/usr/bin/env" = "/usr/bin/env";
           "${builtins.unsafeDiscardStringContext pkgs.pkgsStatic.busybox}" =

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -231,6 +231,7 @@ in {
                 authResponseHeaders = [
                   "X-Auth-Request-User"
                   "X-Auth-Request-Email"
+                  "X-Auth-Request-Access-Token"
                   "Authorization"
                 ];
                 trustForwardHeader = true;

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -229,8 +229,8 @@ in {
               forwardAuth = {
                 address = "https://oauth.${domain}/";
                 authResponseHeaders = [
+                  "X-Auth-Request-User"
                   "X-Auth-Request-Email"
-                  "X-Auth-Request-Access-Token"
                   "Authorization"
                 ];
                 trustForwardHeader = true;

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -1,5 +1,9 @@
-{ self, lib, pkgs, config, nodeName, bittelib, hashiTokens, letsencryptCertMaterial, ... }: {
-
+{ self, lib, pkgs, config, nodeName, bittelib, hashiTokens, letsencryptCertMaterial, pkiFiles, ... }:
+let
+  deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
+  domain = config.${if deployType == "aws" then "cluster" else "currentCoreNode"}.domain;
+  cfg = config.services.traefik;
+in {
   imports = [
     ./common.nix
     ./consul/client.nix
@@ -8,17 +12,35 @@
     ./auxiliaries/oauth.nix
   ];
 
-  options.services.traefik.prometheusPort = lib.mkOption {
-    type = with lib.types; int;
-    default = 9090;
-    description =
-      "The default port for traefik prometheus to publish metrics on.";
+  options.services.traefik = {
+    prometheusPort = lib.mkOption {
+      type = with lib.types; int;
+      default = 9090;
+      description =
+        "The default port for traefik prometheus to publish metrics on.";
+    };
+
+    acmeDnsCertMgr = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        If true, acme systemd services will manage a single cert and provide it to traefik:
+          - using dns Let's Encrypt challenge
+          - using extraAcmeSANs which allow wildcards
+          - utilizing route53 services
+        If false, traefik will manage certs:
+          - using http Let's Encrypt challenge
+          - without other nameserver or DNS service depedencies
+          - by obtaining individual certs for each traefik router service, including nomad job app routes
+      '';
+    };
   };
 
   config = {
     services.traefik.enable = true;
+    services.consul.ui = true;
 
-    systemd.services.copy-acme-certs = {
+    systemd.services.copy-acme-certs = lib.mkIf cfg.acmeDnsCertMgr {
       before = [ "traefik.service" ];
       wantedBy = [ "traefik.service" ];
 
@@ -42,12 +64,12 @@
       '';
     };
 
-    systemd.services."acme-${nodeName}".serviceConfig = {
+    systemd.services."acme-${nodeName}".serviceConfig = lib.mkIf cfg.acmeDnsCertMgr {
       ExecStartPre = bittelib.ensureDependencies pkgs [ "vault-agent" ];
       RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
     };
 
-    security.acme = {
+    security.acme = lib.mkIf cfg.acmeDnsCertMgr {
       acceptTerms = true;
       certs.routing = lib.mkIf (nodeName == "routing") {
         dnsProvider = "route53";
@@ -55,12 +77,11 @@
         email = "devops@iohk.io";
         inherit (config.cluster) domain;
         credentialsFile = builtins.toFile "nothing" "";
-        extraDomainNames = [ "*.${config.cluster.domain}" ]
+        extraDomainNames = [ "*.${domain}" ]
           ++ config.cluster.extraAcmeSANs;
         postRun = ''
           cp fullchain.pem ${letsencryptCertMaterial.certChainFile}
           cp key.pem ${letsencryptCertMaterial.keyFile}
-          cp cert.pem ${letsencryptCertMaterial.certFile}
           systemctl try-restart --no-block traefik.service
 
           export VAULT_TOKEN="$(< ${hashiTokens.vault})"
@@ -73,36 +94,159 @@
     };
 
     services.traefik = {
-      dynamicConfigOptions = {
-        tls.certificates = [{
-          certFile = "/var/lib/traefik/certs/${builtins.baseNameOf letsencryptCertMaterial.certChainFile}";
-          keyFile = "/var/lib/traefik/certs/${builtins.baseNameOf letsencryptCertMaterial.keyFile}";
-        }];
-
+      dynamicConfigOptions = let
+        tlsCfg = if cfg.acmeDnsCertMgr then true else { certresolver = "acme"; };
+      in {
         http = {
-          routers = {
-            traefik = {
-              rule = "Host(`routing.${config.cluster.domain}`)";
-              service = "api@internal";
+          routers = let
+            mkOauthRoute = service: {
+              inherit service;
               entrypoints = "https";
+              middlewares = [ "oauth-auth-redirect" ];
+              rule = "Host(`${service}.${domain}`) && PathPrefix(`/`)";
+              tls = tlsCfg;
+            };
+          in lib.mkDefault {
+            oauth2-route = {
+              entrypoints = "https";
+              middlewares = [ "auth-headers" ];
+              rule = "PathPrefix(`/oauth2/`)";
+              service = "oauth-backend";
+              priority = 999;
               tls = true;
+            };
+
+            oauth2-proxy-route = {
+              entrypoints = "https";
+              middlewares = [ "auth-headers" ];
+              rule = "Host(`oauth.${domain}`) && PathPrefix(`/`)";
+              service = "oauth-backend";
+              tls = tlsCfg;
+            };
+
+            grafana = mkOauthRoute "monitoring";
+            nomad = mkOauthRoute "nomad";
+
+            nomad-api = {
+              entrypoints = "https";
+              middlewares = [ ];
+              rule = "Host(`nomad.${domain}`) && PathPrefix(`/v1/`)";
+              service = "nomad";
+              tls = true;
+            };
+
+            vault = mkOauthRoute "vault";
+
+            vault-api = {
+              entrypoints = "https";
+              middlewares = [ ];
+              rule = "Host(`vault.${domain}`) && PathPrefix(`/v1/`)";
+              service = "vault";
+              tls = true;
+            };
+
+            consul = mkOauthRoute "consul";
+
+            consul-api = {
+              entrypoints = "https";
+              middlewares = [ ];
+              rule = "Host(`consul.${domain}`) && PathPrefix(`/v1/`)";
+              service = "consul";
+              tls = true;
+            };
+
+            traefik = {
+              entrypoints = "https";
+              middlewares = [ "oauth-auth-redirect" ];
+              # middlewares = [ ];
+              rule = "Host(`traefik.${domain}`) && PathPrefix(`/`)";
+              service = "api@internal";
+              tls = tlsCfg;
+            };
+          };
+
+          services = {
+            oauth-backend.loadBalancer = {
+              servers = [{ url = "http://127.0.0.1:4180"; }];
+            };
+
+            consul.loadBalancer = {
+              servers = [{ url = "http://127.0.0.1:8500"; }];
+            };
+
+            nomad.loadBalancer = {
+              servers = [{ url = "https://nomad.service.consul:4646"; }];
+              serversTransport = "cert-transport";
+            };
+
+            monitoring.loadBalancer = {
+              servers = [{ url = "http://monitoring:3000"; }];
+            };
+
+            vault.loadBalancer = {
+              servers = [{ url = "https://active.vault.service.consul:8200"; }];
+              serversTransport = "cert-transport";
+            };
+          };
+
+          serversTransports = {
+            cert-transport = {
+              insecureSkipVerify = true;
+              rootCAs = let
+                certChainFile = if deployType == "aws" then pkiFiles.certChainFile
+                                                       else pkiFiles.serverCertChainFile;
+              in [ certChainFile ];
+            };
+          };
+
+          middlewares = {
+            auth-headers = {
+              headers = {
+                browserXssFilter = true;
+                contentTypeNosniff = true;
+                forceSTSHeader = true;
+                frameDeny = true;
+                sslHost = domain;
+                sslRedirect = true;
+                stsIncludeSubdomains = true;
+                stsPreload = true;
+                stsSeconds = 315360000;
+              };
+            };
+
+            oauth-auth-redirect = {
+              forwardAuth = {
+                address = "https://oauth.${domain}/";
+                authResponseHeaders = [
+                  "X-Auth-Request-Email"
+                  "X-Auth-Request-Access-Token"
+                  "Authorization"
+                ];
+                trustForwardHeader = true;
+              };
             };
           };
         };
       };
 
       staticConfigOptions = {
-        metrics.prometheus = {
-          entrypoint = "metrics";
-          addEntryPointsLabels = true;
-          addServicesLabels = true;
+        metrics = {
+          prometheus = {
+            entrypoint = "metrics";
+            addEntryPointsLabels = true;
+            addServicesLabels = true;
+          };
         };
+
+        accesslog = true;
+        log.level = "info";
 
         api = { dashboard = true; };
 
         entryPoints = {
           http = {
             address = ":80";
+            forwardedHeaders.insecure = true;
             http = {
               redirections = {
                 entryPoint = {
@@ -113,11 +257,24 @@
             };
           };
 
-          https = { address = ":443"; };
+          https = {
+            address = ":443";
+            forwardedHeaders.insecure = true;
+          };
 
           metrics = {
             address =
               "127.0.0.1:${toString config.services.traefik.prometheusPort}";
+          };
+        };
+
+        certificatesResolvers = lib.mkIf (!cfg.acmeDnsCertMgr) {
+          acme = {
+            acme = {
+              email = "devops@iohk.io";
+              storage = "/var/lib/traefik/acme.json";
+              httpChallenge = { entrypoint = "http"; };
+            };
           };
         };
 
@@ -140,9 +297,6 @@
             address = "127.0.0.1:${toString config.services.consul.ports.http}";
 
             scheme = "http";
-
-            # Defines the datacenter to use. If not provided in Traefik, Consul uses the default agent datacenter.
-            datacenter = config.cluster.region;
 
             # Token is used to provide a per-request ACL token which overwrites the agent's default token.
             # token = ""

--- a/profiles/vault/client.nix
+++ b/profiles/vault/client.nix
@@ -18,7 +18,8 @@
   in {
     services.vault-agent = {
       role = "client";
-      vaultAddress = "https://vault.${domain}"; # avoid depending on consul
+      vaultAddress = if deployType == "aws" then "https://vault.${domain}"
+                     else "https://core.vault.service.consul:8200";
       cache.useAutoAuthToken = true;
       listener = [{
           type = "tcp";

--- a/profiles/vault/common.nix
+++ b/profiles/vault/common.nix
@@ -1,12 +1,17 @@
 { config, lib, pkgs, ... }: let
 
-  Imports = { imports = [ ]; };
+  Imports = { imports = [
+    ./secrets-provisioning/cert-identity.nix
+  ]; };
 
   Switches = {
     services.vault-agent.enable = true;
   };
 
-  Config = {
+  Config = let
+    cfg = config.services.vault-agent;
+    deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
+  in {
     environment.variables.VAULT_ADDR = lib.mkDefault "http://127.0.0.1:8200";
     services.vault-agent = {
       vaultAddress = lib.mkDefault "https://core.vault.service.consul:8200";
@@ -15,14 +20,19 @@
         address = "127.0.0.1:8200";
         tlsDisable = true;
       }];
-      autoAuthMethod = "aws";
 
-      autoAuthConfig = {
+      autoAuthMethod = if deployType == "aws" then "aws" else "cert";
+
+      autoAuthConfig = if cfg.autoAuthMethod == "aws" then {
         type = "iam";
         role = "${config.cluster.name}-${config.services.vault-agent.role}";
         header_value = config.cluster.domain;
-      };
-
+      } else if cfg.autoAuthMethod == "cert" then {
+        name = "vault-agent-${cfg.role}";
+        ca_cert = config.age.secrets.vault-ca.path;
+        client_cert = config.age.secrets.vault-client.path;
+        client_key = config.age.secrets.vault-client-key.path;
+      } else (abort "Unknown vault autoAuthMethod");
     };
   };
 

--- a/profiles/vault/monitoring.nix
+++ b/profiles/vault/monitoring.nix
@@ -4,7 +4,6 @@
     ./common.nix
 
     ./secrets-provisioning/hashistack.nix
-    ./secrets-provisioning/letsencrypt-ingress.nix
   ]; };
 
   Switches = { };

--- a/profiles/vault/policies.nix
+++ b/profiles/vault/policies.nix
@@ -27,6 +27,7 @@ in {
       "consul/creds/consul-default".capabilities = [ r u ];
       "kv/data/bootstrap/clients/*".capabilities = [ r ];
       "kv/data/bootstrap/static-tokens/clients/*".capabilities = [ r ];
+      # "pki/issue/client".capabilities = [ u ];
       "pki/issue/client".capabilities = [ c u ];
       "pki/roles/client".capabilities = [ r ];
     };

--- a/profiles/vault/policies.nix
+++ b/profiles/vault/policies.nix
@@ -8,6 +8,28 @@ let
   s = "sudo";
 in {
   services.vault.policies = {
+    # Role for prem or premSim
+    vault-agent-core.path = {
+      "auth/token/create".capabilities = [ c r u d l s ];
+      "consul/creds/nomad-server".capabilities = [ r ];
+      "consul/creds/consul-server-default".capabilities = [ r ];
+      "consul/creds/consul-server-agent".capabilities = [ r ];
+      "nomad/creds/*".capabilities = [ r ];
+      "nomad/role/admin".capabilities = [ u ];
+      "sys/policies/acl/admin".capabilities = [ u ];
+      "sys/storage/raft/snapshot".capabilities = [ r ];
+    };
+
+    # Role for prem or premSim
+    vault-agent-client.path = {
+      "auth/token/create".capabilities = [ c r u d l s ];
+      "consul/creds/consul-agent".capabilities = [ r u ];
+      "consul/creds/consul-default".capabilities = [ r u ];
+      "kv/data/bootstrap/clients/*".capabilities = [ r ];
+      "kv/data/bootstrap/static-tokens/clients/*".capabilities = [ r ];
+      "pki/issue/client".capabilities = [ c u ];
+      "pki/roles/client".capabilities = [ r ];
+    };
 
     core.path = {
       "auth/token/create".capabilities = [ c r u d l s ];

--- a/profiles/vault/policies.nix
+++ b/profiles/vault/policies.nix
@@ -11,27 +11,31 @@ let
 in {
   services.vault.policies = {
     # Role for prem or premSim
-    vault-agent-core.path = lib.mkIf (deployType != "aws") {
-      "auth/token/create".capabilities = [ c r u d l s ];
-      "consul/creds/nomad-server".capabilities = [ r ];
-      "consul/creds/consul-server-default".capabilities = [ r ];
-      "consul/creds/consul-server-agent".capabilities = [ r ];
-      "nomad/creds/*".capabilities = [ r ];
-      "nomad/role/admin".capabilities = [ u ];
-      "sys/policies/acl/admin".capabilities = [ u ];
-      "sys/storage/raft/snapshot".capabilities = [ r ];
+    vault-agent-core = lib.mkIf (deployType != "aws") {
+      path = {
+        "auth/token/create".capabilities = [ c r u d l s ];
+        "consul/creds/nomad-server".capabilities = [ r ];
+        "consul/creds/consul-server-default".capabilities = [ r ];
+        "consul/creds/consul-server-agent".capabilities = [ r ];
+        "nomad/creds/*".capabilities = [ r ];
+        "nomad/role/admin".capabilities = [ u ];
+        "sys/policies/acl/admin".capabilities = [ u ];
+        "sys/storage/raft/snapshot".capabilities = [ r ];
+      };
     };
 
     # Role for prem or premSim
-    vault-agent-client.path = lib.mkIf (deployType != "aws") {
-      "auth/token/create".capabilities = [ c r u d l s ];
-      "consul/creds/consul-agent".capabilities = [ r u ];
-      "consul/creds/consul-default".capabilities = [ r u ];
-      "kv/data/bootstrap/clients/*".capabilities = [ r ];
-      "kv/data/bootstrap/static-tokens/clients/*".capabilities = [ r ];
-      # "pki/issue/client".capabilities = [ u ];
-      "pki/issue/client".capabilities = [ c u ];
-      "pki/roles/client".capabilities = [ r ];
+    vault-agent-client = lib.mkIf (deployType != "aws") {
+      path = {
+        "auth/token/create".capabilities = [ c r u d l s ];
+        "consul/creds/consul-agent".capabilities = [ r u ];
+        "consul/creds/consul-default".capabilities = [ r u ];
+        "kv/data/bootstrap/clients/*".capabilities = [ r ];
+        "kv/data/bootstrap/static-tokens/clients/*".capabilities = [ r ];
+        # "pki/issue/client".capabilities = [ u ];
+        "pki/issue/client".capabilities = [ c u ];
+        "pki/roles/client".capabilities = [ r ];
+      };
     };
 
     core.path = {

--- a/profiles/vault/policies.nix
+++ b/profiles/vault/policies.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, lib, ... }:
 let
   c = "create";
   r = "read";
@@ -6,10 +6,12 @@ let
   d = "delete";
   l = "list";
   s = "sudo";
+
+  deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
 in {
   services.vault.policies = {
     # Role for prem or premSim
-    vault-agent-core.path = {
+    vault-agent-core.path = lib.mkIf (deployType != "aws") {
       "auth/token/create".capabilities = [ c r u d l s ];
       "consul/creds/nomad-server".capabilities = [ r ];
       "consul/creds/consul-server-default".capabilities = [ r ];
@@ -21,7 +23,7 @@ in {
     };
 
     # Role for prem or premSim
-    vault-agent-client.path = {
+    vault-agent-client.path = lib.mkIf (deployType != "aws") {
       "auth/token/create".capabilities = [ c r u d l s ];
       "consul/creds/consul-agent".capabilities = [ r u ];
       "consul/creds/consul-default".capabilities = [ r u ];

--- a/profiles/vault/secrets-provisioning/cert-identity.nix
+++ b/profiles/vault/secrets-provisioning/cert-identity.nix
@@ -1,0 +1,48 @@
+{ config, lib, pkgs, pkiFiles, ... }:
+let
+  deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
+in {
+  age.secrets = lib.mkIf (deployType != "aws") {
+    vault-full-server = {
+      file = config.age.encryptedRoot + "/ssl/server-full.age";
+      path = "/etc/ssl/certs/server-full.pem";
+      mode = "0644";
+    };
+
+    vault-full-client = {
+      file = config.age.encryptedRoot + "/ssl/client-full.age";
+      path = "/etc/ssl/certs/client-full.pem";
+      mode = "0644";
+    };
+
+    vault-ca = {
+      file = config.age.encryptedRoot + "/ssl/ca.age";
+      path = "/etc/ssl/certs/ca.pem";
+      mode = "0644";
+    };
+
+    vault-server = {
+      file = config.age.encryptedRoot + "/ssl/server.age";
+      path = "/etc/ssl/certs/server.pem";
+      mode = "0644";
+    };
+
+    vault-server-key = {
+      file = config.age.encryptedRoot + "/ssl/server-key.age";
+      path = "/etc/ssl/certs/server-key.pem";
+      mode = "0600";
+    };
+
+    vault-client = {
+      file = config.age.encryptedRoot + "/ssl/client.age";
+      path = "/etc/ssl/certs/client.pem";
+      mode = "0644";
+    };
+
+    vault-client-key = {
+      file = config.age.encryptedRoot + "/ssl/client-key.age";
+      path = "/etc/ssl/certs/client-key.pem";
+      mode = "0600";
+    };
+  };
+}

--- a/profiles/vault/secrets-provisioning/host-identity.nix
+++ b/profiles/vault/secrets-provisioning/host-identity.nix
@@ -1,5 +1,7 @@
 { config, lib, pkgs, pkiFiles, ... }: let
 
+  deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
+
   reload = service: "${pkgs.systemd}/bin/systemctl try-reload-or-restart ${service}";
   restart = service: "${pkgs.systemd}/bin/systemctl try-restart ${service}";
 
@@ -20,7 +22,7 @@
   pkiSecret = ''"pki/issue/client" ${toString pkiArgs}'';
 
 in {
-  services.vault-agent.templates = {
+  services.vault-agent.templates = lib.mkIf (deployType == "aws") {
     "${pkiFiles.certChainFile}" = {
       command = restart "certs-updated.service";
       contents = ''


### PR DESCRIPTION
Features:
* Allows premise simulation on aws infra
* Introduces a `deployType` attr ("aws", "premSim", "prem") available in currentCoreNode, currentAwsAutoScalingGroup, etc.
* Adds alternative cert identity authentication vs. aws IAM services for prem and premSim deploys
* Adds Ruby support for rakefile custom cert and age encrypted file generation from a consuming `-ops` repo
* Adds `acmeDnsCertMgr` option traefik option, defaulting to true for DNS challenge supporting wildcards so that existing behavior is preserved.  If set to false, HTTP challenge is instead used and certs will be generated via nomad job traefik tag defns instead of wildcard SANs in a single cert issuance by ACME service.
* Utilizes age, `.agenix.toml` and age module for prem and premSim secrets

Required Migrations:
* With this PR, monitoring, nomad, consul, vault UI and API load are now routed through traefik vs. monitoring; ingress service is no longer used on monitoring.
* This change will require aws deployments to now define route53 for those domains through `routing` instead of `monitoring`
* When utilizing premSim or prem deployment types, core nodes require the bootstrapper ssh pubkey to be added to `users.users.root.openssh.authorizedKeys.keyFiles` to facilitate vault bootstrap initialization and unsealing from the bootstrapper.

Future improvements:
* Age module and agenix toml usage can be bumped to newer age module version and ragenix usage in a future PR
* Another prem oriented deploy branch is in the works on the heels of this one