### PR TITLE
Fix secret provisioning

### DIFF
--- a/profiles/auxiliaries/builder.nix
+++ b/profiles/auxiliaries/builder.nix
@@ -54,7 +54,7 @@ in {
   '';
 
   secrets.install.builder-private-ssh-key = lib.mkIf (isAsg && isSops) {
-    source = (toString config.secrets.encryptedRoot) + "/nix-builder-key";
+    source = config.secrets.encryptedRoot + "/nix-builder-key";
     target = /etc/nix/builder-key;
     inputType = "binary";
     outputType = "binary";
@@ -108,7 +108,7 @@ in {
     builder = {
       isSystemUser = true;
       openssh.authorizedKeys.keyFiles =
-        [ ((toString config.secrets.encryptedRoot) + "/nix-builder-key.pub") ];
+        [ (config.secrets.encryptedRoot + "/nix-builder-key.pub") ];
       shell = pkgs.bashInteractive;
     };
   };

--- a/profiles/auxiliaries/oauth.nix
+++ b/profiles/auxiliaries/oauth.nix
@@ -30,7 +30,7 @@ in {
   secrets.install.oauth.script = lib.mkIf isSops ''
     export PATH="${lib.makeBinPath (with pkgs; [ sops coreutils ])}"
 
-    cat ${(toString config.secrets.encryptedRoot) + "/oauth-secrets"} \
+    cat ${config.secrets.encryptedRoot + "/oauth-secrets"} \
       | sops -d /dev/stdin \
       > /run/keys/oauth-secrets
 

--- a/profiles/bootstrap/default.nix
+++ b/profiles/bootstrap/default.nix
@@ -33,15 +33,15 @@ let
 
   initialVaultSecrets = if deployType == "aws" then ''
     sops --decrypt --extract '["encrypt"]' ${
-      (toString config.secrets.encryptedRoot) + "/consul-clients.json"
+      config.secrets.encryptedRoot + "/consul-clients.json"
     } | vault kv put kv/bootstrap/clients/consul encrypt=-
 
     sops --decrypt --extract '["server"]["encrypt"]' ${
-      (toString config.secrets.encryptedRoot) + "/nomad.json"
+      config.secrets.encryptedRoot + "/nomad.json"
     } | vault kv put kv/bootstrap/clients/nomad encrypt=-
 
     sops --decrypt ${
-      (toString config.secrets.encryptedRoot) + "/nix-cache.json"
+      config.secrets.encryptedRoot + "/nix-cache.json"
     } | vault kv put kv/bootstrap/cache/nix-key -
   '' else ''
     rage -i /etc/ssh/ssh_host_ed25519_key -d ${config.age.encryptedRoot + "/consul/encrypt.age"} \

--- a/profiles/monitoring.nix
+++ b/profiles/monitoring.nix
@@ -100,7 +100,7 @@ in {
 
     mkdir -p /var/lib/grafana
 
-    cat ${(toString config.secrets.encryptedRoot) + "/grafana-password.json"} \
+    cat ${config.secrets.encryptedRoot + "/grafana-password.json"} \
       | sops -d /dev/stdin \
       > /var/lib/grafana/password
   '';

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -305,10 +305,10 @@ in {
           cache = false;
 
           # Enable Consul Connect support.
-          connectaware = true;
+          # connectaware = true;
 
           # Consider every service as Connect capable by default.
-          connectbydefault = false;
+          # connectbydefault = false;
 
           endpoint = {
             # Defines the address of the Consul server.


### PR DESCRIPTION
Doing a `toString` destroys the path which refers to the secret as being needed. This is fine on installation as the paths should exist.

@johnalotoski I'm not sure about the connectaware stuff for traefik ,but traefik wouldn't start without it. I likely need to modify consul on my end.