### PR TITLE
Prem prep rebase

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,20 @@
 GEM
-  specs:
-
-GEM
   remote: https://rubygems.org/
   specs:
     citrus (3.0.2)
     coderay (1.1.3)
-    ed25519 (1.2.4)
+    ed25519 (1.3.0)
     method_source (1.0.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.6)
-    ssh_data (1.2.0)
-    toml-rb (2.1.0)
+    ssh_data (1.3.0)
+    toml-rb (2.1.2)
       citrus (~> 3.0, > 3.0)
 
 PLATFORMS
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   ed25519!
@@ -27,4 +24,4 @@ DEPENDENCIES
   toml-rb!
 
 BUNDLED WITH
-   2.2.24
+   2.1.4

--- a/flake.lock
+++ b/flake.lock
@@ -40,6 +40,28 @@
     "agenix_2": {
       "inputs": {
         "nixpkgs": [
+          "cli",
+          "ragenix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1643841757,
+        "narHash": "sha256-9tKhu4JzoZvustC9IEWK6wKcDhPLuK/ICbLgm8QnLnk=",
+        "owner": "ryantm",
+        "repo": "agenix",
+        "rev": "a17d1f30550260f8b45764ddbd0391f4b1ed714a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryantm",
+        "repo": "agenix",
+        "type": "github"
+      }
+    },
+    "agenix_3": {
+      "inputs": {
+        "nixpkgs": [
           "ragenix",
           "nixpkgs"
         ]
@@ -110,21 +132,21 @@
         "devshell": "devshell",
         "fenix": "fenix",
         "iogo": "iogo",
-        "nix": "nix",
         "nixpkgs": [
           "cli",
           "fenix",
           "nixpkgs"
         ],
+        "ragenix": "ragenix",
         "treefmt": "treefmt",
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1641496331,
-        "narHash": "sha256-QYiCzz+9xDN/n0pWmGpQPTSv+/0Ye9YFc0ltoZ8uvZA=",
+        "lastModified": 1645157801,
+        "narHash": "sha256-0DJd39WaBJX83NaNy+MtDRpv1JlyM9pv7yDXwOEyxVg=",
         "owner": "input-output-hk",
         "repo": "bitte-cli",
-        "rev": "45d479715dc2b02569494a4ffd5db2bcc560f72a",
+        "rev": "9fc8745be860534cbdf156d5153fc08c2929cb3b",
         "type": "github"
       },
       "original": {
@@ -159,12 +181,16 @@
       }
     },
     "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_3"
+      },
       "locked": {
-        "lastModified": 1637575296,
-        "narHash": "sha256-ZY8YR5u8aglZPe27+AJMnPTG6645WuavB+w0xmhTarw=",
+        "lastModified": 1643749865,
+        "narHash": "sha256-S0KM5OdAIikDYGfpcFTzZ+3E/cTNZOp0DJ9j7Lm2OOE=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "0e56ef21ba1a717169953122c7415fa6a8cd2618",
+        "rev": "3552704e5bdbf5e0342eb46e91ab3adab941097d",
         "type": "github"
       },
       "original": {
@@ -175,15 +201,15 @@
     },
     "fenix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1645079077,
-        "narHash": "sha256-0dS1mkM6UaCNdixDuwj2xHyaRqhk9fXDLrfQRmOryBA=",
+        "lastModified": 1643782989,
+        "narHash": "sha256-7get5nUAUiZ/9CYW8bbrLhA5LDORdFeCTpKesOyE98g=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "1a1694cb7ae3708a90932e7a8a9a767c466a2976",
+        "rev": "bc649b429aa1fabce3ec7ca476ef377c86647797",
         "type": "github"
       },
       "original": {
@@ -194,7 +220,7 @@
     },
     "fenix_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_6",
         "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
@@ -244,6 +270,36 @@
     },
     "flake-utils_2": {
       "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
         "lastModified": 1610051610,
         "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
         "owner": "numtide",
@@ -257,7 +313,7 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
+    "flake-utils_5": {
       "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
@@ -272,7 +328,7 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_6": {
       "locked": {
         "lastModified": 1634851050,
         "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
@@ -388,50 +444,11 @@
         "type": "github"
       }
     },
-    "lowdown-src_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": [
-          "cli",
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1645128370,
-        "narHash": "sha256-XtjveEPLGhHPh95+yequcLajtyCskSUTx+XZsP4UqA0=",
-        "owner": "nixos",
-        "repo": "nix",
-        "rev": "a768e85e2fb3b0500829bc42cdc137176481bedf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix_2": {
-      "inputs": {
-        "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_5",
-        "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
         "lastModified": 1645189081,
@@ -447,11 +464,11 @@
         "type": "github"
       }
     },
-    "nix_3": {
+    "nix_2": {
       "inputs": {
-        "lowdown-src": "lowdown-src_3",
-        "nixpkgs": "nixpkgs_7",
-        "nixpkgs-regression": "nixpkgs-regression_3"
+        "lowdown-src": "lowdown-src_2",
+        "nixpkgs": "nixpkgs_9",
+        "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
         "lastModified": 1645189081,
@@ -511,19 +528,36 @@
         "type": "indirect"
       }
     },
-    "nixpkgs-regression_3": {
+    "nixpkgs_10": {
       "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "lastModified": 1645010845,
+        "narHash": "sha256-hO9X4PvxkSLMQnGGB7tOrKPwufhLMiNQMNXNwzLqneo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "rev": "2128d0aa28edef51fd8fef38b132ffc0155595df",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1644525281,
+        "narHash": "sha256-D3VuWLdnLmAXIkooWAtbTGSQI9Fc1lkvAr94wTxhnTU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "48d63e924a2666baf37f4f14a18f19347fbd54a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
@@ -544,27 +578,27 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1644525281,
-        "narHash": "sha256-D3VuWLdnLmAXIkooWAtbTGSQI9Fc1lkvAr94wTxhnTU=",
-        "owner": "nixos",
+        "lastModified": 1643381941,
+        "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48d63e924a2666baf37f4f14a18f19347fbd54a2",
+        "rev": "5efc8ca954272c4376ac929f4c5ffefcc20551d5",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1644525281,
-        "narHash": "sha256-D3VuWLdnLmAXIkooWAtbTGSQI9Fc1lkvAr94wTxhnTU=",
+        "lastModified": 1643524588,
+        "narHash": "sha256-Qh5AazxdOQRORbGkkvpKoovDl6ej/4PhDabFsqnueqw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48d63e924a2666baf37f4f14a18f19347fbd54a2",
+        "rev": "efeefb2af1469a5d1f0ae7ca8f0dfd9bb87d5cfb",
         "type": "github"
       },
       "original": {
@@ -576,32 +610,33 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
-        "owner": "NixOS",
+        "lastModified": 1644525281,
+        "narHash": "sha256-D3VuWLdnLmAXIkooWAtbTGSQI9Fc1lkvAr94wTxhnTU=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "rev": "48d63e924a2666baf37f4f14a18f19347fbd54a2",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1638452135,
-        "narHash": "sha256-5Il6hgrTgcWIsB7zug0yDFccYXx7pJCw8cwJdXMuLfM=",
+        "lastModified": 1644525281,
+        "narHash": "sha256-D3VuWLdnLmAXIkooWAtbTGSQI9Fc1lkvAr94wTxhnTU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "43cdc5b364511eabdcad9fde639777ffd9e5bab1",
+        "rev": "48d63e924a2666baf37f4f14a18f19347fbd54a2",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "rev": "43cdc5b364511eabdcad9fde639777ffd9e5bab1",
         "type": "github"
       }
     },
@@ -622,40 +657,39 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1645010845,
-        "narHash": "sha256-hO9X4PvxkSLMQnGGB7tOrKPwufhLMiNQMNXNwzLqneo=",
-        "owner": "NixOS",
+        "lastModified": 1638452135,
+        "narHash": "sha256-5Il6hgrTgcWIsB7zug0yDFccYXx7pJCw8cwJdXMuLfM=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2128d0aa28edef51fd8fef38b132ffc0155595df",
+        "rev": "43cdc5b364511eabdcad9fde639777ffd9e5bab1",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-21.11",
+        "owner": "nixos",
         "repo": "nixpkgs",
+        "rev": "43cdc5b364511eabdcad9fde639777ffd9e5bab1",
         "type": "github"
       }
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1644525281,
-        "narHash": "sha256-D3VuWLdnLmAXIkooWAtbTGSQI9Fc1lkvAr94wTxhnTU=",
-        "owner": "nixos",
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48d63e924a2666baf37f4f14a18f19347fbd54a2",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
       }
     },
     "nomad": {
       "inputs": {
-        "nix": "nix_3",
-        "nixpkgs": "nixpkgs_8",
+        "nix": "nix_2",
+        "nixpkgs": "nixpkgs_10",
         "utils": "utils_4"
       },
       "locked": {
@@ -693,8 +727,29 @@
       "inputs": {
         "agenix": "agenix_2",
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_5",
         "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1645147603,
+        "narHash": "sha256-xraqK0vwr+AF9om7b3xIaP5AqEQqMb1DLVuUjGzM+98=",
+        "owner": "input-output-hk",
+        "repo": "ragenix",
+        "rev": "194a625a97262f704b619acfccf27a5b9e6faea8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "ragenix",
+        "type": "github"
+      }
+    },
+    "ragenix_2": {
+      "inputs": {
+        "agenix": "agenix_3",
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": "nixpkgs_11",
+        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
         "lastModified": 1641119695,
@@ -718,8 +773,8 @@
         "cli": "cli",
         "deploy": "deploy",
         "hydra": "hydra",
-        "nix": "nix_2",
-        "nixpkgs": "nixpkgs_6",
+        "nix": "nix",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-client": [
           "nixpkgs"
         ],
@@ -728,7 +783,7 @@
         ],
         "nomad": "nomad",
         "ops-lib": "ops-lib",
-        "ragenix": "ragenix",
+        "ragenix": "ragenix_2",
         "terranix": "terranix",
         "utils": "utils_5",
         "vulnix": "vulnix"
@@ -737,11 +792,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1645024434,
-        "narHash": "sha256-ZYwqOkx9MYKmbuqkLJdRhIn7IghMRclbUzxJgR7OOhA=",
+        "lastModified": 1643756728,
+        "narHash": "sha256-46tA2m137jpmhDjjOJLaAi8z44zra6qYMTZgKpbyqHM=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "89faff7477e904f6820990f130a3aed72c1d7e6b",
+        "rev": "34138379b5945616e51b3822769628b252c7a4f5",
         "type": "github"
       },
       "original": {
@@ -769,6 +824,33 @@
       }
     },
     "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "cli",
+          "ragenix",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "cli",
+          "ragenix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1644633594,
+        "narHash": "sha256-Te6mBYYirUwsoqENvVx1K1EEoRq2CKrTnNkWF42jNgE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "14c48021a9a5fe6ea8ae6b21c15caa106afa9d19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
       "inputs": {
         "flake-utils": [
           "ragenix",
@@ -812,7 +894,7 @@
       "inputs": {
         "bats-assert": "bats-assert",
         "bats-support": "bats-support",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_6",
         "nixpkgs": [
           "blank"
         ],
@@ -849,18 +931,18 @@
     },
     "treefmt": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": [
           "cli",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1639763815,
-        "narHash": "sha256-PTT87Na4KpyN6a7T49vHHhSqSOF6JSWr5/jiys1Uzko=",
+        "lastModified": 1640364438,
+        "narHash": "sha256-sV1Oa9JVNmpAwZ4cnVs7ovHrKL8EPg3J08jPX/a48LI=",
         "owner": "numtide",
         "repo": "treefmt",
-        "rev": "871b10dba4e8732aeac4cce57ba2336ce6e6c9e8",
+        "rev": "26d7f5f15e5d22d4413ba7c5ae0447fdc0b5cc76",
         "type": "github"
       },
       "original": {
@@ -886,11 +968,11 @@
     },
     "utils_2": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
         "type": "github"
       },
       "original": {

--- a/gemset.nix
+++ b/gemset.nix
@@ -24,10 +24,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1f5kr8za7hvla38fc0n9jiv55iq62k5bzclsa5kdb14l3r4w6qnw";
+      sha256 = "0zb2dr2ihb1qiknn5iaj1ha1w9p7lj9yq5waasndlfadz225ajji";
       type = "gem";
     };
-    version = "1.2.4";
+    version = "1.3.0";
   };
   method_source = {
     groups = ["default"];
@@ -65,10 +65,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0p3vaq2fbmlphphqr0yjc5cyzzxjizq4zbxbbw3j2vpgdcmpi6bs";
+      sha256 = "1h5aiqqlk51z12kgvanhdvd0ajvv2i68z6a7450yxgmflfaiwz7c";
       type = "gem";
     };
-    version = "1.2.0";
+    version = "1.3.0";
   };
   toml-rb = {
     dependencies = ["citrus"];
@@ -76,9 +76,9 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1mrr8c9agmf9l9gs63lnsqzc62x08hj673yix7bjss1kvagwjnsr";
+      sha256 = "18ihbwncslffpai40wdm2jrgfjp27hw5lcqcddaz733pvv405nff";
       type = "gem";
     };
-    version = "2.1.0";
+    version = "2.1.2";
   };
 }

--- a/lib/clusters.nix
+++ b/lib/clusters.nix
@@ -24,7 +24,7 @@ lib.listToAttrs (lib.forEach bitteProfiles (bitteProfile:
                throw "Duplicate node name: ${name}"
              else
                name) v)) [ ] names;
-       in builtins.seq combinedNames (cluster.coreNodes // cluster.premSimNodes);
+       in builtins.deepSeq combinedNames (cluster.coreNodes // cluster.premSimNodes);
 
     ourMkSystem = attr: nodeName: coreNode: (mkSystem {
       inherit pkgs self inputs ;

--- a/lib/mk-deploy.nix
+++ b/lib/mk-deploy.nix
@@ -19,7 +19,7 @@ let
       profiles.system.path =
         let inherit (cfg.pkgs) system;
         in deploy.lib.${system}.activate.nixos cfg;
-    } // (lib.optionalAttrs (cfg.config.currentCoreNode.deployType  == "prem") {
+    } // (lib.optionalAttrs ((cfg.config.currentCoreNode.deployType or cfg.config.currentAwsAutoScalingGroup.deployType) == "prem") {
       hostname = cfg.config.cluster.name + "-" + cfg.config.networking.hostName;
       sshOpts = [ "-C" "-o" "StrictHostKeyChecking=no" ];
     })) self.nixosConfigurations;

--- a/lib/mk-system.nix
+++ b/lib/mk-system.nix
@@ -66,7 +66,6 @@ let
       ../profiles/ami-base-config.nix
     ];
   });
-
 in {
   inherit bitteSystem bitteProtoSystem bitteAmazonSystem
     bitteAmazonSystemBaseAMI bitteAmazonZfsSystem bitteAmazonZfsSystemBaseAMI;

--- a/lib/mk-system/constants-module.nix
+++ b/lib/mk-system/constants-module.nix
@@ -14,7 +14,6 @@ in {
       keyFile = "/etc/ssl/certs/cert-key.pem";
 
       # "prem" and "premSim" deployType cert files
-      vaultCaCertFile = "/etc/ssl/certs/vault-ca.pem";
       clientCertFile = "/etc/ssl/certs/client.pem";
       clientKeyFile = "/etc/ssl/certs/client-key.pem";
       clientCertChainFile = "/etc/ssl/certs/client-full.pem";

--- a/lib/mk-system/constants-module.nix
+++ b/lib/mk-system/constants-module.nix
@@ -14,6 +14,7 @@ in {
       keyFile = "/etc/ssl/certs/cert-key.pem";
 
       # "prem" and "premSim" deployType cert files
+      vaultCaCertFile = "/etc/ssl/certs/vault-ca.pem";
       clientCertFile = "/etc/ssl/certs/client.pem";
       clientKeyFile = "/etc/ssl/certs/client-key.pem";
       clientCertChainFile = "/etc/ssl/certs/client-full.pem";

--- a/modules/age.nix
+++ b/modules/age.nix
@@ -5,7 +5,11 @@ with lib;
 let
   cfg = config.age;
 
-  ageBin = "${pkgs.age}/bin/age";
+  # This pin has a 20 recipient limit
+  # Ref:
+  #  https://github.com/FiloSottile/age/issues/139
+  # ageBin = "${pkgs.age}/bin/age";
+  ageBin = "${pkgs.rage}/bin/rage";
 
   users = config.users.users;
 

--- a/modules/consul.nix
+++ b/modules/consul.nix
@@ -346,6 +346,8 @@ in {
 
       verifyIncoming = lib.mkEnableOption "Verify incoming conns";
 
+      verifyIncomingRpc = lib.mkEnableOption "Verify incoming rpc conns";
+
       verifyOutgoing = lib.mkEnableOption "Verify outgoing conns";
 
       verifyServerHostname = lib.mkEnableOption "Verify server hostname";
@@ -444,7 +446,7 @@ in {
           ui datacenter bootstrapExpect bindAddr advertiseAddr server logLevel
           clientAddr encrypt addresses recursors retryJoin primaryDatacenter
           acl connect caFile certFile keyFile autoEncrypt verifyServerHostname
-          verifyOutgoing verifyIncoming dataDir tlsMinVersion ports
+          verifyOutgoing verifyIncoming verifyIncomingRpc dataDir tlsMinVersion ports
           enableLocalScriptChecks nodeMeta telemetry nodeId enableDebug
           enableScriptChecks;
       });

--- a/modules/consul.nix
+++ b/modules/consul.nix
@@ -62,7 +62,7 @@ in {
 
       serverNodeNames = lib.mkOption {
         type = with lib.types; listOf str;
-        default = if deployType == "aws" then [ "core-1" "core-2" "core-3" ]
+        default = if deployType != "premSim" then [ "core-1" "core-2" "core-3" ]
                   else [ "prem-1" "prem-2" "prem-3" ];
       };
 

--- a/modules/consul.nix
+++ b/modules/consul.nix
@@ -369,6 +369,26 @@ in {
                 type = with lib.types; nullOr port;
                 default = null;
               };
+
+              sidecarMinPort = lib.mkOption {
+                type = with lib.types; nullOr port;
+                default = null;
+              };
+
+              sidecarMaxPort = lib.mkOption {
+                type = with lib.types; nullOr port;
+                default = null;
+              };
+
+              exposeMinPort = lib.mkOption {
+                type = with lib.types; nullOr port;
+                default = null;
+              };
+
+              exposeMaxPort = lib.mkOption {
+                type = with lib.types; nullOr port;
+                default = null;
+              };
             };
           };
       };

--- a/modules/consul.nix
+++ b/modules/consul.nix
@@ -202,6 +202,20 @@ in {
         default = { };
       };
 
+      recursors = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = "0.0.0.0";
+        description = ''
+          This flag provides addresses of upstream DNS servers that are used to
+          recursively resolve queries if they are not inside the service domain
+          for Consul. For example, a node can use Consul directly as a DNS server,
+          and if the record is outside of the "consul." domain, the query will be
+          resolved upstream. As of Consul 1.0.1 recursors can be provided as IP
+          addresses or as go-sockaddr templates. IP addresses are resolved in
+          order, and duplicates are ignored.
+        '';
+      };
+
       retryJoin = lib.mkOption {
         type = with lib.types; listOf str;
         default = [ ];
@@ -408,8 +422,8 @@ in {
       pkgs.toPrettyJSON "config" (sanitize {
         inherit (cfg)
           ui datacenter bootstrapExpect bindAddr advertiseAddr server logLevel
-          clientAddr encrypt addresses retryJoin primaryDatacenter acl connect
-          caFile certFile keyFile autoEncrypt verifyServerHostname
+          clientAddr encrypt addresses recursors retryJoin primaryDatacenter
+          acl connect caFile certFile keyFile autoEncrypt verifyServerHostname
           verifyOutgoing verifyIncoming dataDir tlsMinVersion ports
           enableLocalScriptChecks nodeMeta telemetry nodeId enableDebug
           enableScriptChecks;

--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -185,7 +185,7 @@ in {
 
     serverNodeNames = lib.mkOption {
       type = with lib.types; listOf str;
-      default = if deployType == "aws" then [ "core-1" "core-2" "core-3" ]
+      default = if deployType != "premSim" then [ "core-1" "core-2" "core-3" ]
                 else [ "prem-1" "prem-2" "prem-3" ];
     };
 

--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -1189,10 +1189,10 @@ in {
       };
 
       serviceConfig = let
-        certChainFile = if deployType == "aws" then pkiFiles.certChainFile
-                      else pkiFiles.serverCertChainFile;
-        certKeyFile = if deployType == "aws" then pkiFiles.keyFile
-                      else pkiFiles.serverKeyFile;
+        certChainFile = if (deployType != "aws" && cfg.server.enabled) then pkiFiles.serverCertChainFile
+                        else pkiFiles.certChainFile;
+        certKeyFile = if (deployType != "aws" && cfg.server.enabled) then pkiFiles.serverKeyFile
+                      else pkiFiles.keyFile;
         start-pre = pkgs.writeBashChecked "nomad-start-pre" ''
           PATH="${lib.makeBinPath [ pkgs.coreutils pkgs.busybox ]}"
           set -exuo pipefail

--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -307,6 +307,36 @@ in {
               '';
             };
 
+            min_dynamic_port = lib.mkOption {
+              type = with lib.types; nullOr ints.unsigned;
+              default = null;
+              description = ''
+                Specifies the minimum dynamic port to be assigned.
+                Individual ports and ranges of ports may be excluded from dynamic
+                port assignment via reserved parameters.
+
+                NOTE: Nomad uses port 20000 for this parameter by default.
+                This is within Consul's dynamic port range and may cause jobs
+                to fail randomly in a busy deployment if unadjusted.
+
+                Refs:
+                  https://www.nomadproject.io/docs/job-specification/network#dynamic-ports
+                  https://www.consul.io/docs/agent/options#ports
+                  https://github.com/hashicorp/consul/issues/12253
+                  https://github.com/hashicorp/nomad/issues/4285
+              '';
+            };
+
+            max_dynamic_port = lib.mkOption {
+              type = with lib.types; nullOr ints.unsigned;
+              default = null;
+              description = ''
+                Specifies the maximum dynamic port to be assigned.
+                Individual ports and ranges of ports may be excluded from dynamic
+                port assignment via reserved parameters.
+              '';
+            };
+
             node_class = lib.mkOption {
               type = with lib.types; nullOr str;
               default = null;
@@ -1131,11 +1161,6 @@ in {
     environment.systemPackages = [ pkgs.nomad ];
 
     users.extraUsers.nobody = { };
-
-    networking.firewall = {
-      allowedTCPPorts = [ 4646 4647 4648 ];
-      allowedUDPPorts = [ 4648 ];
-    };
 
     systemd.services.nomad = {
       after = [ "network-online.target" "vault-agent.service" ];

--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -1165,11 +1165,9 @@ in {
 
       serviceConfig = let
         certChainFile = if deployType == "aws" then pkiFiles.certChainFile
-                      else if cfg.server.enabled then pkiFiles.serverCertChainFile
-                      else pkiFiles.clientCertChainFile;
+                      else pkiFiles.serverCertChainFile;
         certKeyFile = if deployType == "aws" then pkiFiles.keyFile
-                      else if cfg.server.enabled then pkiFiles.serverKeyFile
-                      else pkiFiles.clientKeyFile;
+                      else pkiFiles.serverKeyFile;
         start-pre = pkgs.writeBashChecked "nomad-start-pre" ''
           PATH="${lib.makeBinPath [ pkgs.coreutils pkgs.busybox ]}"
           set -exuo pipefail

--- a/modules/promtail.nix
+++ b/modules/promtail.nix
@@ -13,7 +13,7 @@ let
 
     clients = [{
       url =
-        "http://${config.cluster.coreNodes.monitoring.privateIP}:3100/loki/api/v1/push";
+        "http://${config.cluster.nodes.monitoring.privateIP}:3100/loki/api/v1/push";
     }];
 
     positions = { filename = "/var/lib/promtail/positions.yaml"; };

--- a/modules/telegraf.nix
+++ b/modules/telegraf.nix
@@ -9,7 +9,7 @@ let
     mkdir -p /etc/telegraf
 
     ${pkgs.jq}/bin/jq \
-      < ${pkgs.writeText "config.json" (builtins.toJSON cfg.extraConfig)} \
+      < ${pkgs.writeText "config.json" (builtins.toJSON (lib.recursiveUpdate cfg.extraConfig cfg.overrides))} \
       --arg host "$(${pkgs.nettools}/bin/hostname)" '.global_tags.hostname = $host' \
       | ${pkgs.remarshal}/bin/remarshal -if json -of toml \
       > /etc/telegraf/config.toml
@@ -46,6 +46,13 @@ in {
             };
           };
         };
+      };
+
+      # TODO: There is probably a better way to do this
+      overrides = mkOption {
+        default = { };
+        description = "An overrides attr to allow better attr merge support to extraConfig";
+        type = types.attrs;
       };
     };
   };

--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -362,6 +362,11 @@ let
           default = self.outPath;
         };
 
+        vaultBackend = lib.mkOption {
+          type = with lib.types; str;
+          default = "https://vault.infra.aws.iohkdev.io";
+        };
+
         vbkBackend = lib.mkOption {
           type = with lib.types; str;
           default = "https://vbk.infra.aws.iohkdev.io";
@@ -1029,7 +1034,7 @@ in {
       type = with lib.types;
         attrsOf (submodule ({ name, ... }@this: {
           options = let
-            backend = "${cfg.vbkBackend}/v1";
+            backend = "${cfg.vaultBackend}/v1";
 
             # If no kms cluster key is present, use prem deploy-rs equivalent commands
             coreNode = if cfg.infraType == "prem" then "${cfg.name}-core-1" else "core-1";

--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -655,6 +655,11 @@ let
           default = "aws";
         };
 
+        primaryInterface = lib.mkOption {
+          type = with lib.types; str;
+          default = "ens5";
+        };
+
         ami = lib.mkOption {
           type = with lib.types; str;
           default = config.cluster.ami;
@@ -799,6 +804,11 @@ let
         deployType = lib.mkOption {
           type = with lib.types; enum [ "aws" "prem" "premSim" ];
           default = "aws";
+        };
+
+        primaryInterface = lib.mkOption {
+          type = with lib.types; str;
+          default = "ens5";
         };
 
         ami = lib.mkOption {

--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -1059,7 +1059,7 @@ in {
                 echo Fetching nomad bootstrap token for hydrate-cluster.
                 echo This is a standard requirement since nomad does not
                 echo implement fine-grained ACL. Hence, for hydrate-cluster
-                echo a management token is required. The boostrap token is
+                echo a management token is required. The bootstrap token is
                 echo such a management token.
                 echo Fetching from '${coreNode}', the presumed bootstrapper ...
                 echo -----------------------------------------------------
@@ -1124,7 +1124,10 @@ in {
                 echo
                 echo -----------------------------------------------------
                 echo TIP: you can avoid repetitive calls to the infra auth
-                echo api by exporting the following env variables as is:
+                echo api by exporting the following env variables as is.
+                echo
+                echo The current vault backend in use for TF is:
+                echo ${cfg.vaultBackend}
                 echo -----------------------------------------------------
                 echo "export TF_HTTP_USERNAME=\"$user\""
                 echo "export TF_HTTP_PASSWORD=\"$pass\""

--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -710,6 +710,7 @@ let
                     else if lib.hasPrefix "monitor" name then "monitor"
                     else if lib.hasPrefix "hydra" name then "hydra"
                     else if lib.hasPrefix "storage" name then "storage"
+                    else if lib.hasPrefix "client" name then "client"
                     else "default";
         };
 
@@ -858,6 +859,11 @@ let
         };
 
         node_class = lib.mkOption { type = with lib.types; str; };
+
+        role = lib.mkOption {
+          type = with lib.types; str;
+          default = "client";
+        };
 
         modules = lib.mkOption {
           type = with lib.types; listOf (oneOf [ path attrs (functionTo attrs) ]);

--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -937,7 +937,7 @@ in {
               throw "Duplicate node name: ${name}"
             else
               name) v)) [ ] names;
-      in builtins.seq combinedNames
+      in builtins.deepSeq combinedNames
       (cfg.coreNodes."${nodeName}" or
        cfg.premNodes."${nodeName}" or
        cfg.premSimNodes."${nodeName}" or

--- a/modules/terraform/aws_policies.nix
+++ b/modules/terraform/aws_policies.nix
@@ -4,16 +4,18 @@
 #   - aws_iam_role
 #   - aws_iam_role_policy
 # - It is also a reference for data points in core.nix & clients.nix
-# - Keem these machine AWS IAM policies separate in here for overview
+# - Keep these machine AWS IAM policies separate in here for overview
 # - Find (more volatile) operator policies in hydrate.nix
 
 { self, lib, pkgs, config, terralib, ... }:
 let
   inherit (terralib) allowS3For;
+  inherit (config.cluster) infraType;
+
   bucketArn = "arn:aws:s3:::${config.cluster.s3Bucket}";
   allowS3ForBucket = allowS3For bucketArn;
 in {
-  cluster.iam = {
+  cluster.iam = lib.mkIf (infraType != "prem") {
     roles = {
       client = {
         assumePolicy = {

--- a/modules/terraform/clients.nix
+++ b/modules/terraform/clients.nix
@@ -3,7 +3,7 @@ let
   inherit (terralib)
     id var regions awsProviderNameFor awsProviderFor mkSecurityGroupRule
     nullRoute nullRouteInline;
-  inherit (config.cluster) vbkBackend vbkBackendSkipCertVerification;
+  inherit (config.cluster) infraType vbkBackend vbkBackendSkipCertVerification;
 
   merge = lib.foldl' lib.recursiveUpdate { };
 
@@ -41,7 +41,7 @@ let
         vpcRegions);
   in f: lib.listToAttrs (lib.forEach peeringPairs f);
 in {
-  tf.clients.configuration = {
+  tf.clients.configuration = lib.mkIf (infraType != "prem") {
     terraform.backend.http = let
       vbk =
         "${vbkBackend}/state/${config.cluster.name}/clients";

--- a/modules/terraform/clients.nix
+++ b/modules/terraform/clients.nix
@@ -40,8 +40,13 @@ let
       (lib.imap0 (i: connector: regionPeeringPairs vpcRegions connector i)
         vpcRegions);
   in f: lib.listToAttrs (lib.forEach peeringPairs f);
+
+  infraTypeCheck = if builtins.elem infraType [ "aws" "premSim" ] then true else (throw ''
+    To utilize the clients TF attr, the cluster config parameter `infraType`
+    must either "aws" or "premSim".
+  '');
 in {
-  tf.clients.configuration = lib.mkIf (infraType != "prem") {
+  tf.clients.configuration = lib.mkIf infraTypeCheck {
     terraform.backend.http = let
       vbk =
         "${vbkBackend}/state/${config.cluster.name}/clients";

--- a/modules/terraform/clients.nix
+++ b/modules/terraform/clients.nix
@@ -3,6 +3,7 @@ let
   inherit (terralib)
     id var regions awsProviderNameFor awsProviderFor mkSecurityGroupRule
     nullRoute nullRouteInline;
+  inherit (config.cluster) vbkBackend vbkBackendSkipCertVerification;
 
   merge = lib.foldl' lib.recursiveUpdate { };
 
@@ -43,11 +44,12 @@ in {
   tf.clients.configuration = {
     terraform.backend.http = let
       vbk =
-        "https://vbk.infra.aws.iohkdev.io/state/${config.cluster.name}/clients";
+        "${vbkBackend}/state/${config.cluster.name}/clients";
     in {
       address = vbk;
       lock_address = vbk;
       unlock_address = vbk;
+      skip_cert_verification = vbkBackendSkipCertVerification;
     };
 
     terraform.required_providers = pkgs.terraform-provider-versions;

--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -7,8 +7,13 @@ let
 
   merge = lib.foldl' lib.recursiveUpdate { };
   tags = { Cluster = config.cluster.name; };
+
+  infraTypeCheck = if builtins.elem infraType [ "aws" "premSim" ] then true else (throw ''
+    To utilize the core TF attr, the cluster config parameter `infraType`
+    must either "aws" or "premSim".
+  '');
 in {
-  tf.core.configuration = lib.mkIf (infraType != "prem") {
+  tf.core.configuration = lib.mkIf infraTypeCheck {
     terraform.backend.http = let
       vbk =
         "${vbkBackend}/state/${config.cluster.name}/core";

--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -3,12 +3,12 @@ let
   inherit (terralib)
     var id pp regions awsProviderNameFor awsProviderFor mkSecurityGroupRule
     nullRoute;
-  inherit (config.cluster) vbkBackend vbkBackendSkipCertVerification;
+  inherit (config.cluster) infraType vbkBackend vbkBackendSkipCertVerification;
 
   merge = lib.foldl' lib.recursiveUpdate { };
   tags = { Cluster = config.cluster.name; };
 in {
-  tf.core.configuration = {
+  tf.core.configuration = lib.mkIf (infraType != "prem") {
     terraform.backend.http = let
       vbk =
         "${vbkBackend}/state/${config.cluster.name}/core";

--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -3,6 +3,7 @@ let
   inherit (terralib)
     var id pp regions awsProviderNameFor awsProviderFor mkSecurityGroupRule
     nullRoute;
+  inherit (config.cluster) vbkBackend vbkBackendSkipCertVerification;
 
   merge = lib.foldl' lib.recursiveUpdate { };
   tags = { Cluster = config.cluster.name; };
@@ -10,11 +11,12 @@ in {
   tf.core.configuration = {
     terraform.backend.http = let
       vbk =
-        "https://vbk.infra.aws.iohkdev.io/state/${config.cluster.name}/core";
+        "${vbkBackend}/state/${config.cluster.name}/core";
     in {
       address = vbk;
       lock_address = vbk;
       unlock_address = vbk;
+      skip_cert_verification = vbkBackendSkipCertVerification;
     };
 
     terraform.required_providers = pkgs.terraform-provider-versions;

--- a/modules/terraform/hydrate-cluster/docker-pwd.nix
+++ b/modules/terraform/hydrate-cluster/docker-pwd.nix
@@ -1,8 +1,10 @@
 # Load docker developer password into vault
-{ config, terralib, ... }:
-let inherit (terralib) var;
+{ config, terralib, lib, ... }:
+let
+  inherit (terralib) var;
+  inherit (config.cluster) infraType;
 in {
-  tf.hydrate-cluster.configuration = {
+  tf.hydrate-cluster.configuration = lib.mkIf (infraType != "prem") {
 
     data.sops_file.docker-developer-password.source_file =
       "${config.secrets.encryptedRoot + "/docker-passwords.json"}";

--- a/modules/terraform/hydrate-cluster/policies-aws.toml
+++ b/modules/terraform/hydrate-cluster/policies-aws.toml
@@ -1,0 +1,11 @@
+[vault] # policy roles
+
+[vault.admin]
+path."aws/*".capabilities = [ "create", "read", "update", "delete", "list" ]
+path."auth/aws/config/client".capabilities = [ "create", "read", "update", "delete", "list" ]
+path."auth/aws/role/*".capabilities = [ "create", "read", "update", "delete", "list" ]
+path."sys/auth/aws".capabilities = [ "create", "read", "update", "delete", "list", "sudo" ]
+
+
+[vault.developer]
+path."aws/creds/developer".capabilities = [ "read", "update", ] # Allow creating AWS tokens

--- a/modules/terraform/hydrate-cluster/policies-base.toml
+++ b/modules/terraform/hydrate-cluster/policies-base.toml
@@ -2,7 +2,6 @@
 
 [vault.admin]
 path."approle/*".capabilities = [ "create", "read", "update", "delete", "list" ]
-path."aws/*".capabilities = [ "create", "read", "update", "delete", "list" ]
 path."consul/*".capabilities = [ "create", "read", "update", "delete", "list" ]
 path."kv/*".capabilities = [ "create", "read", "update", "delete", "list" ]
 path."nomad/*".capabilities = [ "create", "read", "update", "delete", "list" ]
@@ -11,8 +10,6 @@ path."runtime/*".capabilities = [ "create", "read", "update", "delete", "list" ]
 path."sops/*".capabilities = [ "create", "read", "update", "delete", "list" ]
 path."starttime/*".capabilities = [ "create", "read", "update", "delete", "list" ] # Starttime app secrets (accessible by nomad-cluster role)
 
-path."auth/aws/config/client".capabilities = [ "create", "read", "update", "delete", "list" ]
-path."auth/aws/role/*".capabilities = [ "create", "read", "update", "delete", "list" ]
 path."auth/github-employees/config".capabilities = [ "create", "read", "update", "delete", "list", "sudo" ]
 path."auth/github-employees/map/teams/*".capabilities = [ "create", "read", "update", "delete", "list", "sudo" ]
 path."auth/github-terraform/config".capabilities = [ "create", "read", "update", "delete", "list", "sudo" ]
@@ -31,7 +28,6 @@ path."auth/token/roles/*".capabilities = [ "create", "read", "update", "delete",
 path."auth/token/roles/nomad-cluster".capabilities = [ "create", "read", "update", "delete", "list" ]
 path."auth/token/roles/nomad-server".capabilities = [ "read" ]
 path."identity/*".capabilities = [ "create", "read", "update", "delete", "list" ]
-path."sys/auth/aws".capabilities = [ "create", "read", "update", "delete", "list", "sudo" ]
 path."sys/auth".capabilities = [ "read", "list" ]
 path."sys/auth/github-employees".capabilities = [ "create", "read", "update", "delete", "list", "sudo" ]
 path."sys/auth/github-employees/config".capabilities = [ "create", "read" ]
@@ -47,7 +43,6 @@ path."sys/policy/*".capabilities = [ "create", "read", "update", "delete", "list
 
 
 [vault.developer]
-path."aws/creds/developer".capabilities = [ "read", "update", ] # Allow creating AWS tokens
 path."consul/creds/developer".capabilities = [ "read", "update", ] # Allow creating Consul tokens
 path."nomad/creds/developer".capabilities = [ "read", "update", ] # Allow creating Nomad tokens
 path."sops/dev".capabilities = [ "read", "list", ] # Allow to decrypt dev sops secrets

--- a/modules/terraform/hydrate-cluster/vault-aws-auth.nix
+++ b/modules/terraform/hydrate-cluster/vault-aws-auth.nix
@@ -1,8 +1,11 @@
 # hydrate-cluster.aws groups & policies
-{ terralib, ... }:
-let inherit (terralib) var;
+{ terralib, config, lib, ... }:
+let
+  inherit (terralib) var;
+  inherit (config.cluster) infraType;
+
 in {
-  tf.hydrate-cluster.configuration = {
+  tf.hydrate-cluster.configuration = lib.mkIf (infraType != "prem") {
 
     resource.aws_iam_group = {
       developers = {

--- a/modules/terraform/hydrate-cluster/vault-github-auth.nix
+++ b/modules/terraform/hydrate-cluster/vault-github-auth.nix
@@ -1,8 +1,8 @@
 # Bootstrap vault github employee & aws backend.
 { terralib, lib, config, ... }:
 let
-
   inherit (terralib) var;
+  inherit (config.cluster) infraType;
 
 in {
   tf.hydrate-cluster.configuration = {
@@ -37,7 +37,7 @@ in {
             policies = [ "developer" "default" ];
           })));
 
-    resource.vault_aws_secret_backend_role = {
+    resource.vault_aws_secret_backend_role = lib.mkIf (infraType != "prem") {
       developers = {
         backend = "aws";
         name = "developer";

--- a/modules/terraform/hydrate.nix
+++ b/modules/terraform/hydrate.nix
@@ -8,8 +8,9 @@
 { self, lib, pkgs, config, terralib, ... }:
 let
   inherit (terralib) regions awsProviderNameFor awsProviderFor;
+  inherit (config.cluster) vbkBackend vbkBackendSkipCertVerification;
 
-  vbkStub = "https://vbk.infra.aws.iohkdev.io/state/${config.cluster.name}";
+  vbkStub = "${vbkBackend}/state/${config.cluster.name}";
 
 in {
 
@@ -20,7 +21,8 @@ in {
     Please rename your infra cluster tf vault backend accordingly and switch!
 
     CLI Migration:
-      VAULT_ADDR=https://vault.infra.aws.iohkdev.io
+      # VAULT_ADDR would typically be: https://vault.infra.aws.iohkdev.io
+      VAULT_ADDR=<VAULT_ADDR>
       VAULT_TOKEN=$VAULT_INFRA_OPS_ADMIN_TOKEN
       vault kv put secret/vbk/$BITTE_CLUSTER/hydrate-secrets @<(vault kv get -format=json secret/vbk/$BITTE_CLUSTER/secrets-hydrate | jq .data.data)
 
@@ -32,6 +34,7 @@ in {
       address = "${vbkStub}/hydrate-secrets";
       lock_address = "${vbkStub}/hydrate-secrets";
       unlock_address = "${vbkStub}/hydrate-secrets";
+      skip_cert_verification = vbkBackendSkipCertVerification;
     };
     terraform.required_providers = pkgs.terraform-provider-versions;
     provider.vault = { };
@@ -44,7 +47,8 @@ in {
     Please rename your infra cluster tf vault backend accordingly and switch!
 
     CLI Migration:
-      VAULT_ADDR=https://vault.infra.aws.iohkdev.io
+      # VAULT_ADDR would typically be: https://vault.infra.aws.iohkdev.io
+      VAULT_ADDR=<VAULT_ADDR>
       VAULT_TOKEN=$VAULT_INFRA_OPS_ADMIN_TOKEN
       vault kv put secret/vbk/$BITTE_CLUSTER/hydrate-app @<(vault kv get -format=json secret/vbk/$BITTE_CLUSTER/app-hydrate | jq .data.data)
 
@@ -56,6 +60,7 @@ in {
       address = "${vbkStub}/hydrate-app";
       lock_address = "${vbkStub}/hydrate-app";
       unlock_address = "${vbkStub}/hydrate-app";
+      skip_cert_verification = vbkBackendSkipCertVerification;
     };
     terraform.required_providers = pkgs.terraform-provider-versions;
     provider.vault = { };
@@ -68,7 +73,8 @@ in {
     Please rename your infra cluster tf vault backend accordingly and switch!
 
     CLI Migration:
-      VAULT_ADDR=https://vault.infra.aws.iohkdev.io
+      # VAULT_ADDR would typically be: https://vault.infra.aws.iohkdev.io
+      VAULT_ADDR=<VAULT_ADDR>
       VAULT_TOKEN=$VAULT_INFRA_OPS_ADMIN_TOKEN
       vault kv put secret/vbk/$BITTE_CLUSTER/hydrate-cluster @<(vault kv get -format=json secret/vbk/$BITTE_CLUSTER/hydrate | jq .data.data)
 
@@ -81,6 +87,7 @@ in {
       address = "${vbkStub}/hydrate-cluster";
       lock_address = "${vbkStub}/hydrate-cluster";
       unlock_address = "${vbkStub}/hydrate-cluster";
+      skip_cert_verification = vbkBackendSkipCertVerification;
     };
     terraform.required_providers = pkgs.terraform-provider-versions;
     provider.vault = { };

--- a/modules/terraform/prem_sim.nix
+++ b/modules/terraform/prem_sim.nix
@@ -7,8 +7,13 @@ let
 
   merge = lib.foldl' lib.recursiveUpdate { };
   tags = { Cluster = config.cluster.name; };
+
+  infraTypeCheck = if builtins.elem infraType [ "aws" "premSim" ] then true else (throw ''
+    To utilize the prem-sim TF attr, the cluster config parameter `infraType`
+    must either "aws" or "premSim".
+  '');
 in {
-  tf.prem-sim.configuration = lib.mkIf (infraType == "premSim") {
+  tf.prem-sim.configuration = lib.mkIf infraTypeCheck {
     terraform.backend.http = let
       vbk =
         "${vbkBackend}/state/${config.cluster.name}/prem-sim";

--- a/modules/terraform/prem_sim.nix
+++ b/modules/terraform/prem_sim.nix
@@ -3,6 +3,7 @@ let
   inherit (terralib)
     var id pp regions awsProviderNameFor awsProviderFor mkSecurityGroupRule
     nullRoute;
+  inherit (config.cluster) vbkBackend vbkBackendSkipCertVerification;
 
   merge = lib.foldl' lib.recursiveUpdate { };
   tags = { Cluster = config.cluster.name; };
@@ -10,11 +11,12 @@ in {
   tf.prem-sim.configuration = {
     terraform.backend.http = let
       vbk =
-        "https://vbk.infra.aws.iohkdev.io/state/${config.cluster.name}/prem-sim";
+        "${vbkBackend}/state/${config.cluster.name}/prem-sim";
     in {
       address = vbk;
       lock_address = vbk;
       unlock_address = vbk;
+      skip_cert_verification = vbkBackendSkipCertVerification;
     };
 
     terraform.required_providers = pkgs.terraform-provider-versions;

--- a/modules/terraform/prem_sim.nix
+++ b/modules/terraform/prem_sim.nix
@@ -3,12 +3,12 @@ let
   inherit (terralib)
     var id pp regions awsProviderNameFor awsProviderFor mkSecurityGroupRule
     nullRoute;
-  inherit (config.cluster) vbkBackend vbkBackendSkipCertVerification;
+  inherit (config.cluster) infraType vbkBackend vbkBackendSkipCertVerification;
 
   merge = lib.foldl' lib.recursiveUpdate { };
   tags = { Cluster = config.cluster.name; };
 in {
-  tf.prem-sim.configuration = {
+  tf.prem-sim.configuration = lib.mkIf (infraType == "premSim") {
     terraform.backend.http = let
       vbk =
         "${vbkBackend}/state/${config.cluster.name}/prem-sim";

--- a/modules/vault-agent.nix
+++ b/modules/vault-agent.nix
@@ -137,12 +137,13 @@ in {
       wantedBy = [ "multi-user.target" ];
 
       environment = {
-        inherit (config.environment.variables) AWS_DEFAULT_REGION;
         CONSUL_HTTP_ADDR = "127.0.0.1:8500";
         VAULT_ADDR = cfg.vaultAddress;
         VAULT_SKIP_VERIFY = "true";
         VAULT_FORMAT = "json";
-      };
+      } // (lib.optionalAttrs (config.environment.variables ? "AWS_DEFAULT_REGION") {
+        inherit (config.environment.variables) AWS_DEFAULT_REGION;
+      });
 
       path = with pkgs; [ vault-bin ];
 

--- a/modules/vault-backend.nix
+++ b/modules/vault-backend.nix
@@ -34,6 +34,7 @@ in {
       after = [ "network.target" ];
 
       environment = {
+        VAULT_CACERT = "crt.pem";
         VAULT_URL = "https://core.vault.service.consul:8200";
         VAULT_PREFIX = "vbk"; # the prefix used when storing the secrets
         LISTEN_ADDRESS = "${cfg.interface}:${toString cfg.port}";
@@ -49,8 +50,8 @@ in {
           set -exuo pipefail
           export PATH="${lib.makeBinPath [ pkgs.coreutils ]}"
 
-          cp ${certChainFile} .
-          cp ${certKeyFile} .
+          cp ${certChainFile} crt.pem
+          cp ${certKeyFile} key.pem
           chown --reference . --recursive .
         '';
       in {

--- a/modules/vault-backend.nix
+++ b/modules/vault-backend.nix
@@ -34,7 +34,7 @@ in {
       after = [ "network.target" ];
 
       environment = {
-        VAULT_CACERT = "crt.pem";
+        VAULT_CACERT = "cert.pem";
         VAULT_URL = "https://core.vault.service.consul:8200";
         VAULT_PREFIX = "vbk"; # the prefix used when storing the secrets
         LISTEN_ADDRESS = "${cfg.interface}:${toString cfg.port}";
@@ -50,7 +50,7 @@ in {
           set -exuo pipefail
           export PATH="${lib.makeBinPath [ pkgs.coreutils ]}"
 
-          cp ${certChainFile} crt.pem
+          cp ${certChainFile} cert.pem
           cp ${certKeyFile} key.pem
           chown --reference . --recursive .
         '';

--- a/modules/vault.nix
+++ b/modules/vault.nix
@@ -126,6 +126,25 @@ in {
                 else [ "prem-1" "prem-2" "prem-3" ];
     };
 
+    serverNameAddressing = lib.mkOption {
+      type = with lib.types; bool;
+      default = false;
+      description = ''
+        By default, vault server IPs will be used to specify raft peers, api and cluster addresses.
+        With vault server TLS requirements, the vault server IPs must then be embedded in the cert files.
+        This may force unwanted cert rotation in the case that vault servers change IPs.
+
+        Alternatively, enabling this option will instead utilize the server hostname appended with `.internal`,
+        resolved by hosts file.  Typically this will resolve in core node resolution by hostname via:
+          core-1.internal
+          core-2.internal
+          core-3.internal
+          ...
+
+        The vault server certificate will need to have `core-$n.internal` names added to the cert SAN list.
+      '';
+    };
+
     extraConfig = lib.mkOption {
       type = with lib.types; attrs;
       default = { };

--- a/modules/vault.nix
+++ b/modules/vault.nix
@@ -122,7 +122,7 @@ in {
 
     serverNodeNames = lib.mkOption {
       type = with lib.types; listOf str;
-      default = if deployType == "aws" then [ "core-1" "core-2" "core-3" ]
+      default = if deployType != "premSim" then [ "core-1" "core-2" "core-3" ]
                 else [ "prem-1" "prem-2" "prem-3" ];
     };
 

--- a/profiles/auxiliaries/builder.nix
+++ b/profiles/auxiliaries/builder.nix
@@ -107,8 +107,10 @@ in {
   users.extraUsers = lib.mkIf isMonitoring {
     builder = {
       isSystemUser = true;
-      openssh.authorizedKeys.keyFiles =
-        [ ((toString config.secrets.encryptedRoot) + "/nix-builder-key.pub") ];
+      openssh.authorizedKeys.keyFiles = let
+        builderKey = if isSops then "${toString config.secrets.encryptedRoot}/nix-builder-key.pub"
+                     else config.age.encryptedRoot + "/ssh/builder.age";
+      in [ builderKey ];
       shell = pkgs.bashInteractive;
     };
   };

--- a/profiles/auxiliaries/docker-registry.nix
+++ b/profiles/auxiliaries/docker-registry.nix
@@ -88,6 +88,9 @@ in {
     script = docker-passwords-script "/run/keys/docker-passwords-decrypted";
   };
 
+  # For the prem case, hydrate-secrets handles the push to vault instead of sops
+  # TODO: add proper docker password generation creds in the Rakefile
+  # TODO: add more unified handling between aws and prem secrets
   age.secrets = lib.mkIf (!isSops) {
     docker-passwords = {
       file = config.age.encryptedRoot + "/docker/password.age";

--- a/profiles/auxiliaries/docker-registry.nix
+++ b/profiles/auxiliaries/docker-registry.nix
@@ -10,6 +10,11 @@ let
     chown docker-registry /var/lib/docker-registry/docker-passwords
   '';
 in {
+
+  networking.firewall.allowedTCPPorts = [
+    config.services.dockerRegistry.port
+  ];
+
   systemd.services.docker-registry.serviceConfig.Environment = [
     "REGISTRY_AUTH=htpasswd"
     "REGISTRY_AUTH_HTPASSWD_REALM=docker-registry"

--- a/profiles/auxiliaries/docker-registry.nix
+++ b/profiles/auxiliaries/docker-registry.nix
@@ -23,7 +23,7 @@ in {
 
   services = {
     dockerRegistry = {
-      enable = true;
+      enable = lib.mkDefault true;
       enableDelete = true;
       enableGarbageCollect = true;
       enableRedisCache = true;

--- a/profiles/auxiliaries/docker.nix
+++ b/profiles/auxiliaries/docker.nix
@@ -54,7 +54,7 @@ in {
       fi
     '';
 
-    # Trust traffic originating from the Nomad bridge where nomad bridge jobs are run
+    # Trust traffic originating from the docker bridge where docker driver jobs are run
     networking.firewall.trustedInterfaces = [ "docker0" ];
   };
 }

--- a/profiles/auxiliaries/docker.nix
+++ b/profiles/auxiliaries/docker.nix
@@ -54,10 +54,7 @@ in {
       fi
     '';
 
-    # Allow docker containers to issue DNS queries to the local host, which runs dnsmasq,
-    # which allows them to resolve consul service domains as described in https://www.consul.io/docs/discovery/dns
-    networking.firewall.extraCommands = ''
-      iptables -A INPUT -i docker0 -p udp -m udp --dport 53 -j ACCEPT
-    '';
+    # Trust traffic originating from the Nomad bridge where nomad bridge jobs are run
+    networking.firewall.trustedInterfaces = [ "docker0" ];
   };
 }

--- a/profiles/auxiliaries/docker.nix
+++ b/profiles/auxiliaries/docker.nix
@@ -8,7 +8,7 @@ in {
   options = {
     virtualisation.docker = {
       logLevel = lib.mkOption {
-        type = lib.types.str;
+        type = lib.types.enum [ "debug" "info" "warn" "error" "fatal" ];
         default = "info";
         description = ''
           Set the logging level ("debug"|"info"|"warn"|"error"|"fatal") (default "info")
@@ -57,7 +57,6 @@ in {
       autoPrune.dates = "daily";
 
       extraOptions = lib.concatStringsSep " " ([
-        "--log-level=${cfg.logLevel}"
         "--log-driver=journald"
         # For simplicity, let the bridge network have a static ip/mask (by default it
         # would choose this one, but fall back to the next range if this one is already used)
@@ -65,7 +64,8 @@ in {
         # Which allows us to specify that containers should use the local host as the DNS server
         # This is written into the containers /etc/resolv.conf
         "--dns=172.17.0.1"
-      ] ++ lib.optional (!cfg.logBlockingMode) "--log-opt mode=non-blocking"
+      ] ++ lib.optional (cfg.logLevel != "info") "--log-level=${cfg.logLevel}"
+        ++ lib.optional (!cfg.logBlockingMode) "--log-opt mode=non-blocking"
         ++ lib.optional (!cfg.logBlockingMode) "--log-opt max-buffer-size=${cfg.logMaxBufferSize}"
         ++ (lib.optionals (cfg.insecureRegistries != null)
         # Declares insecure registries to be used TEMPORARILY in a test environment

--- a/profiles/auxiliaries/docker.nix
+++ b/profiles/auxiliaries/docker.nix
@@ -2,42 +2,62 @@
 let
   deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
   primaryInterface = config.currentCoreNode.primaryInterface or config.currentAwsAutoScalingGroup.primaryInterface;
+  cfg = config.virtualisation.docker;
 in {
-  virtualisation.docker.enable = true;
-  virtualisation.docker = {
-    autoPrune.enable = true;
-    autoPrune.dates = "daily";
 
-    extraOptions = lib.concatStringsSep " " [
-      "--log-driver=journald"
-      # For simplicity, let the bridge network have a static ip/mask (by default it
-      # would choose this one, but fall back to the next range if this one is already used)
-      "--bip=172.17.0.1/16"
-      # Which allows us to specify that containers should use the local host as the DNS server
-      # This is written into the containers /etc/resolv.conf
-      "--dns=172.17.0.1"
-    ];
+  options = {
+    virtualisation.docker = {
+      insecureRegistries = lib.mkOption {
+        type = with lib.types; nullOr (listOf str);
+        default = null;
+        description = ''
+          A list of insecure docker repositories where TLS certificate checks will be skipped.
+          Intended only for temporary use in a test environment where trusted certs are not
+          yet available.
+        '';
+      };
+    };
   };
 
-  # needed to access AWS meta-data after docker starts veth* devices.
-  networking.interfaces.${primaryInterface}.ipv4.routes = lib.mkIf (deployType == "aws") [{
-    address = "169.254.169.252";
-    prefixLength = 30;
-  }];
+  config = {
+    virtualisation.docker.enable = true;
+    virtualisation.docker = {
+      autoPrune.enable = true;
+      autoPrune.dates = "daily";
 
-  # Workaround dhcpcd breaking AWS meta-data, resulting in vault-agent failure.
-  # Ref: https://github.com/NixOS/nixpkgs/issues/109389
-  # Rather than explicitly deny all veth* interfaces access to dhcpcd,
-  # ensure the meta-data route is added upon service restart.
-  networking.dhcpcd.runHook = lib.mkIf (deployType == "aws") ''
-    if [ "$reason" = BOUND -o "$reason" = REBOOT ]; then
-      /run/current-system/systemd/bin/systemctl try-reload-or-restart network-addresses-${primaryInterface}.service || true
-    fi
-  '';
+      extraOptions = lib.concatStringsSep " " ([
+        "--log-driver=journald"
+        # For simplicity, let the bridge network have a static ip/mask (by default it
+        # would choose this one, but fall back to the next range if this one is already used)
+        "--bip=172.17.0.1/16"
+        # Which allows us to specify that containers should use the local host as the DNS server
+        # This is written into the containers /etc/resolv.conf
+        "--dns=172.17.0.1"
+      ] ++ (lib.optionals (cfg.insecureRegistries != null)
+        # Declares insecure registries to be used TEMPORARILY in a test environment
+        (map (registry: "--insecure-registry=${registry}") cfg.insecureRegistries)));
+    };
 
-  # Allow docker containers to issue DNS queries to the local host, which runs dnsmasq,
-  # which allows them to resolve consul service domains as described in https://www.consul.io/docs/discovery/dns
-  networking.firewall.extraCommands = ''
-    iptables -A INPUT -i docker0 -p udp -m udp --dport 53 -j ACCEPT
-  '';
+    # needed to access AWS meta-data after docker starts veth* devices.
+    networking.interfaces.${primaryInterface}.ipv4.routes = lib.mkIf (deployType == "aws") [{
+      address = "169.254.169.252";
+      prefixLength = 30;
+    }];
+
+    # Workaround dhcpcd breaking AWS meta-data, resulting in vault-agent failure.
+    # Ref: https://github.com/NixOS/nixpkgs/issues/109389
+    # Rather than explicitly deny all veth* interfaces access to dhcpcd,
+    # ensure the meta-data route is added upon service restart.
+    networking.dhcpcd.runHook = lib.mkIf (deployType == "aws") ''
+      if [ "$reason" = BOUND -o "$reason" = REBOOT ]; then
+        /run/current-system/systemd/bin/systemctl try-reload-or-restart network-addresses-${primaryInterface}.service || true
+      fi
+    '';
+
+    # Allow docker containers to issue DNS queries to the local host, which runs dnsmasq,
+    # which allows them to resolve consul service domains as described in https://www.consul.io/docs/discovery/dns
+    networking.firewall.extraCommands = ''
+      iptables -A INPUT -i docker0 -p udp -m udp --dport 53 -j ACCEPT
+    '';
+  };
 }

--- a/profiles/auxiliaries/loki.nix
+++ b/profiles/auxiliaries/loki.nix
@@ -1,4 +1,8 @@
 _: {
+  networking.firewall.allowedTCPPorts = [
+    3100  # loki
+  ];
+
   services.loki = {
     configuration = {
       auth_enabled = false;

--- a/profiles/auxiliaries/nix.nix
+++ b/profiles/auxiliaries/nix.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, self, ... }: {
+{ pkgs, self, ... }: {
   nix = {
     package = pkgs.nixFlakes;
     gc.automatic = true;
@@ -20,11 +20,10 @@
     };
     systemFeatures = [ "recursive-nix" "nixos-test" ];
 
-    binaryCaches = [ "https://hydra.iohk.io" config.cluster.s3Cache ];
+    binaryCaches = [ "https://hydra.iohk.io" ];
 
     binaryCachePublicKeys = [
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
-      config.cluster.s3CachePubKey
     ];
   };
 }

--- a/profiles/auxiliaries/oauth.nix
+++ b/profiles/auxiliaries/oauth.nix
@@ -5,7 +5,7 @@ let
   isSops = deployType == "aws";
 in {
 
-  services.oauth2_proxy.enable = true;
+  services.oauth2_proxy.enable = lib.mkDefault true;
 
   services.oauth2_proxy = {
     extraConfig.whitelist-domain = ".${domain}";

--- a/profiles/auxiliaries/secrets.nix
+++ b/profiles/auxiliaries/secrets.nix
@@ -221,7 +221,7 @@ in {
     '';
   };
 
-  age.secrets.consul-encrypt = lib.mkIf (!isSops) {
+  age.secrets.consul-encrypt = lib.mkIf (config.services.consul.enable && !isSops) {
     file = config.age.encryptedRoot + /consul/encrypt.age;
     path = gossipEncryptionMaterial.consul;
     mode = "0444";

--- a/profiles/auxiliaries/secrets.nix
+++ b/profiles/auxiliaries/secrets.nix
@@ -238,4 +238,17 @@ in {
         > $out
     '';
   };
+
+  age.secrets.nomad-encrypt = lib.mkIf (config.services.nomad.server.enabled && !isSops) {
+    file = config.age.encryptedRoot + /nomad/encrypt.age;
+    path = gossipEncryptionMaterial.nomad;
+    mode = "0444";
+    script = ''
+      echo '{}' \
+        | ${pkgs.jq}/bin/jq \
+          --arg encrypt "$(< "$src")" \
+          '.server.encrypt = $encrypt' \
+        > $out
+    '';
+  };
 }

--- a/profiles/auxiliaries/telegraf.nix
+++ b/profiles/auxiliaries/telegraf.nix
@@ -1,7 +1,7 @@
 { pkgs, config, lib, pkiFiles, ... }:
 let
   deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
-  datacenter = config.currentCoreNode.datacenter or config.currentAwsAutoScalingGroup.datacenter;
+  datacenter = config.currentCoreNode.datacenter or config.cluster.region;
   role = config.currentCoreNode.role or config.currentAwsAutoScalingGroup.role;
   isClient = role == "client";
 in {
@@ -51,9 +51,7 @@ in {
         metric_buffer_limit = 50000;
       };
 
-      global_tags = {
-        datacenter = if deployType == "aws" then config.cluster.region else datacenter;
-      };
+      global_tags = { inherit datacenter; };
 
       inputs = {
         statsd = {

--- a/profiles/auxiliaries/telegraf.nix
+++ b/profiles/auxiliaries/telegraf.nix
@@ -110,7 +110,9 @@ in {
 
         x509_cert = {
           sources = [
-            (if (deployType != "aws" && !isClient) then pkiFiles.serverCertChainFile else pkiFiles.clientCertFile)
+            (if (deployType != "aws" && !isClient) then pkiFiles.serverCertFile
+             else if (deployType != "aws" && isClient) then pkiFiles.clientCertFile
+             else pkiFiles.certFile)
           ];
         };
 

--- a/profiles/auxiliaries/telegraf.nix
+++ b/profiles/auxiliaries/telegraf.nix
@@ -168,7 +168,7 @@ in {
       outputs = {
         influxdb = {
           database = "telegraf";
-          urls = [ "http://${config.cluster.coreNodes.monitoring.privateIP}:8428" ];
+          urls = [ "http://${config.cluster.nodes.monitoring.privateIP}:8428" ];
         };
       };
     };

--- a/profiles/bootstrap/default.nix
+++ b/profiles/bootstrap/default.nix
@@ -265,6 +265,28 @@ in {
           ''))}
         ''}
 
+        ${lib.optionalString (deployType != "aws") ''
+          # Finally allow cert roles to login to Vault
+
+          vault write auth/cert/certs/vault-agent-core \
+            display_name=vault-agent-core \
+            policies=vault-agent-core \
+            certificate=@"/etc/ssl/certs/client.pem" \
+            ttl=3600
+
+          vault write auth/cert/certs/vault-agent-client \
+            display_name=vault-agent-client \
+            policies=vault-agent-client \
+            certificate=@"/etc/ssl/certs/client.pem" \
+            ttl=3600
+
+          vault write auth/cert/certs/vault-agent-routing \
+            display_name=vault-agent-routing \
+            policies=routing \
+            certificate=@"/etc/ssl/certs/client.pem" \
+            ttl=3600''
+        }
+
         ${initialVaultSecrets}
 
         ${initialVaultStaticSecrets}
@@ -489,25 +511,7 @@ in {
         }
 
         ${lib.optionalString (deployType != "aws") ''
-          echo "$auth" | jq -e '."cert/"'         || vault auth enable cert
-
-          vault write auth/cert/certs/vault-agent-core \
-            display_name=vault-agent-core \
-            policies=vault-agent-core \
-            certificate=@"/etc/ssl/certs/client.pem" \
-            ttl=3600
-
-          vault write auth/cert/certs/vault-agent-client \
-            display_name=vault-agent-client \
-            policies=vault-agent-client \
-            certificate=@"/etc/ssl/certs/client.pem" \
-            ttl=3600
-
-          vault write auth/cert/certs/vault-agent-routing \
-            display_name=vault-agent-routing \
-            policies=routing \
-            certificate=@"/etc/ssl/certs/client.pem" \
-            ttl=3600''
+          echo "$auth" | jq -e '."cert/"'         || vault auth enable cert''
         }
 
         # This lets Vault issue Consul tokens

--- a/profiles/bootstrap/default.nix
+++ b/profiles/bootstrap/default.nix
@@ -193,9 +193,10 @@ in {
       };
 
       environment = {
-        inherit (config.environment.variables)
-          AWS_DEFAULT_REGION VAULT_CACERT VAULT_FORMAT VAULT_ADDR;
-      };
+        inherit (config.environment.variables) VAULT_CACERT VAULT_FORMAT VAULT_ADDR;
+      } // (lib.optionalAttrs (config.environment.variables ? "AWS_DEFAULT_REGION") {
+        inherit (config.environment.variables) AWS_DEFAULT_REGION;
+      });
 
       path = with pkgs; [ sops rage vault-bin consul nomad coreutils jq curl ];
 
@@ -290,10 +291,12 @@ in {
       };
 
       environment = {
-        inherit (config.environment.variables) AWS_DEFAULT_REGION NOMAD_ADDR;
+        inherit (config.environment.variables) NOMAD_ADDR;
         CURL_CA_BUNDLE = if deployType == "aws" then pkiFiles.certChainFile
                          else pkiFiles.serverCertChainFile;
-      };
+      } // (lib.optionalAttrs (config.environment.variables ? "AWS_DEFAULT_REGION") {
+        inherit (config.environment.variables) AWS_DEFAULT_REGION;
+      });
 
       path = with pkgs; [ curl sops rage coreutils jq nomad vault-bin gawk ];
 
@@ -367,9 +370,10 @@ in {
       };
 
       environment = {
-        inherit (config.environment.variables)
-          AWS_DEFAULT_REGION VAULT_CACERT VAULT_FORMAT VAULT_ADDR;
-      };
+        inherit (config.environment.variables) VAULT_CACERT VAULT_FORMAT VAULT_ADDR;
+      } // (lib.optionalAttrs (config.environment.variables ? "AWS_DEFAULT_REGION") {
+        inherit (config.environment.variables) AWS_DEFAULT_REGION;
+      });
 
       path = with pkgs; [
         consul

--- a/profiles/bootstrap/default.nix
+++ b/profiles/bootstrap/default.nix
@@ -271,7 +271,7 @@ in {
           vault write auth/cert/certs/vault-agent-core \
             display_name=vault-agent-core \
             policies=vault-agent-core \
-            certificate=@"/etc/ssl/certs/client.pem" \
+            certificate=@"/etc/ssl/certs/server.pem" \
             ttl=3600
 
           vault write auth/cert/certs/vault-agent-client \
@@ -502,7 +502,6 @@ in {
         echo "$secrets" | jq -e '."kv/"'          || vault secrets enable -version=2 kv
         echo "$secrets" | jq -e '."nomad/"'       || vault secrets enable nomad
         echo "$secrets" | jq -e '."pki/"'         || vault secrets enable pki
-        echo "$secrets" | jq -e '."pki-consul/"'  || vault secrets enable -path pki-consul pki
 
         auth="$(vault auth list)"
 

--- a/profiles/common.nix
+++ b/profiles/common.nix
@@ -18,7 +18,22 @@ in {
   security.polkit.enable = false;
 
   services.ssm-agent.enable = deployType == "aws";
-  services.openntpd.enable = true;
+
+  # Chrony succeeds in quickly syncing large time drift systems,
+  # whereas openntpd may stay unsynced for extended periods.
+  services.chrony.enable = true;
+  networking.timeServers = lib.mkForce [
+    "0.nixos.pool.ntp.org"
+    "1.nixos.pool.ntp.org"
+    "2.nixos.pool.ntp.org"
+    "3.nixos.pool.ntp.org"
+  ];
+
+  # remove after upgrading past 21.05
+  # users.users.ntp.group = "ntp";
+  # users.groups.ntp = { };
+  users.groups.systemd-coredump = { };
+
   services.fail2ban.enable = deployType != "premSim";
 
   environment.variables = {
@@ -28,18 +43,8 @@ in {
 
   # Don't `nixos-rebuild switch` after the initial deploy.
   systemd.services.amazon-init.enable = false;
-  networking.timeServers = lib.mkForce [
-    "0.nixos.pool.ntp.org"
-    "1.nixos.pool.ntp.org"
-    "2.nixos.pool.ntp.org"
-    "3.nixos.pool.ntp.org"
-  ];
-  boot.cleanTmpDir = true;
 
-  # remove after upgrading past 21.05
-  users.users.ntp.group = "ntp";
-  users.groups.ntp = { };
-  users.groups.systemd-coredump = { };
+  boot.cleanTmpDir = true;
 
   networking.firewall = let
     all = {

--- a/profiles/common.nix
+++ b/profiles/common.nix
@@ -58,8 +58,10 @@ in {
   in {
     enable = true;
     allowPing = true;
-    allowedTCPPortRanges = [ all ];
-    allowedUDPPortRanges = [ all ];
+
+    # TODO: deprecate open firewall with SG dependency in aws
+    allowedTCPPortRanges = lib.mkIf (deployType == "aws") [ all ];
+    allowedUDPPortRanges = lib.mkIf (deployType == "aws") [ all ];
   };
 
   # Remove once nixpkgs is using openssh 8.7p1+ by default to avoid coredumps

--- a/profiles/common.nix
+++ b/profiles/common.nix
@@ -33,11 +33,6 @@ in {
     "3.nixos.pool.ntp.org"
   ];
 
-  # remove after upgrading past 21.05
-  # users.users.ntp.group = "ntp";
-  # users.groups.ntp = { };
-  users.groups.systemd-coredump = { };
-
   services.fail2ban.enable = deployType != "premSim";
 
   environment.variables = {

--- a/profiles/common.nix
+++ b/profiles/common.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 let
-  inherit (config.cluster) coreNodes premSimNodes;
+  inherit (config.cluster) nodes coreNodes premNodes premSimNodes;
   deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
 in {
 
@@ -62,10 +62,10 @@ in {
   in ''
     ${lib.concatStringsSep "\n"
     (lib.mapAttrsToList (name: instance: "${instance.privateIP} core.vault.service.consul")
-      (lib.filterAttrs (k: v: lib.elem k serverNodeNames) (premSimNodes // coreNodes)))}
+      (lib.filterAttrs (k: v: lib.elem k serverNodeNames) nodes))}
 
     ${lib.concatStringsSep "\n"
     (lib.mapAttrsToList (name: instance: "${instance.privateIP} ${name}")
-      (if deployType != "premSim" then coreNodes else premSimNodes))}
+      (if deployType != "premSim" then (coreNodes // premNodes) else premSimNodes))}
   '';
 }

--- a/profiles/common.nix
+++ b/profiles/common.nix
@@ -22,6 +22,10 @@ in {
   # Chrony succeeds in quickly syncing large time drift systems,
   # whereas openntpd may stay unsynced for extended periods.
   services.chrony.enable = true;
+
+  # Ensure that the timeservers are able to resolve before iburst probing
+  systemd.services.chronyd.after = lib.mkIf config.services.dnsmasq.enable [ "dnsmasq.service" ];
+
   networking.timeServers = lib.mkForce [
     "0.nixos.pool.ntp.org"
     "1.nixos.pool.ntp.org"

--- a/profiles/common.nix
+++ b/profiles/common.nix
@@ -72,7 +72,7 @@ in {
     inherit (config.services.vault) serverNodeNames;
   in ''
     ${lib.concatStringsSep "\n"
-    (lib.mapAttrsToList (name: instance: "${instance.privateIP} ${name}.internal core.vault.service.consul")
+    (lib.mapAttrsToList (name: instance: "${instance.privateIP} ${name}.internal")
       (lib.filterAttrs (k: v: lib.elem k serverNodeNames) nodes))}
 
     ${lib.concatStringsSep "\n"

--- a/profiles/common.nix
+++ b/profiles/common.nix
@@ -66,7 +66,7 @@ in {
     inherit (config.services.vault) serverNodeNames;
   in ''
     ${lib.concatStringsSep "\n"
-    (lib.mapAttrsToList (name: instance: "${instance.privateIP} core.vault.service.consul")
+    (lib.mapAttrsToList (name: instance: "${instance.privateIP} ${name}.internal core.vault.service.consul")
       (lib.filterAttrs (k: v: lib.elem k serverNodeNames) nodes))}
 
     ${lib.concatStringsSep "\n"

--- a/profiles/consul/client.nix
+++ b/profiles/consul/client.nix
@@ -4,7 +4,40 @@
 
   Switches = {};
 
-  Config = {};
+  Config = let
+    cfg = config.services.consul;
+  in {
+    # Consul firewall references:
+    #   https://support.hashicorp.com/hc/en-us/articles/1500011608961-Checking-Consul-Network-Connectivity
+    #   https://www.consul.io/docs/install/ports
+    #
+    # Consul ports specific to clients also running nomad
+    networking.firewall.allowedTCPPortRanges = lib.mkIf config.services.nomad.enable [
+      {
+        from = cfg.ports.sidecarMinPort;
+        to = cfg.ports.sidecarMaxPort;
+      }
+      {
+        from = cfg.ports.exposeMinPort;
+        to = cfg.ports.exposeMaxPort;
+      }
+    ];
+
+    services.consul.ports = {
+      # Default dynamic port ranges for consul clients.
+      # Nomad default ephemeral dynamic port range will need to be adjusted to avoid random collision.
+      #
+      # Refs:
+      #   https://www.nomadproject.io/docs/job-specification/network#dynamic-ports
+      #   https://www.consul.io/docs/agent/options#ports
+      #   https://github.com/hashicorp/consul/issues/12253
+      #   https://github.com/hashicorp/nomad/issues/4285
+      sidecarMinPort = 21000;
+      sidecarMaxPort = 21255;
+      exposeMinPort = 21500;
+      exposeMaxPort = 21755;
+    };
+  };
 
 in Imports // lib.mkMerge [
   Switches

--- a/profiles/consul/client.nix
+++ b/profiles/consul/client.nix
@@ -6,6 +6,7 @@
 
   Config = let
     cfg = config.services.consul;
+    isDocker = config.virtualisation.docker.enable == true;
   in {
     # Consul firewall references:
     #   https://support.hashicorp.com/hc/en-us/articles/1500011608961-Checking-Consul-Network-Connectivity
@@ -23,19 +24,22 @@
       }
     ];
 
-    services.consul.ports = {
-      # Default dynamic port ranges for consul clients.
-      # Nomad default ephemeral dynamic port range will need to be adjusted to avoid random collision.
-      #
-      # Refs:
-      #   https://www.nomadproject.io/docs/job-specification/network#dynamic-ports
-      #   https://www.consul.io/docs/agent/options#ports
-      #   https://github.com/hashicorp/consul/issues/12253
-      #   https://github.com/hashicorp/nomad/issues/4285
-      sidecarMinPort = 21000;
-      sidecarMaxPort = 21255;
-      exposeMinPort = 21500;
-      exposeMaxPort = 21755;
+    services.consul = {
+      addresses.http = lib.mkIf isDocker "127.0.0.1 {{ GetInterfaceIP \"docker0\" }}";
+      ports = {
+        # Default dynamic port ranges for consul clients.
+        # Nomad default ephemeral dynamic port range will need to be adjusted to avoid random collision.
+        #
+        # Refs:
+        #   https://www.nomadproject.io/docs/job-specification/network#dynamic-ports
+        #   https://www.consul.io/docs/agent/options#ports
+        #   https://github.com/hashicorp/consul/issues/12253
+        #   https://github.com/hashicorp/nomad/issues/4285
+        sidecarMinPort = 21000;
+        sidecarMaxPort = 21255;
+        exposeMinPort = 21500;
+        exposeMaxPort = 21755;
+      };
     };
   };
 

--- a/profiles/consul/common.nix
+++ b/profiles/consul/common.nix
@@ -57,6 +57,9 @@
 
       advertiseAddr = ''{{ GetInterfaceIP "${primaryInterface}" }}'';
 
+      # Allow cname local hostname lookups through consul via dnsmasq recursor
+      recursors = [ ''{{ GetInterfaceIP "${primaryInterface}" }}'' ];
+
       retryJoin = (lib.mapAttrsToList (_: v: v.privateIP)
         (lib.filterAttrs (k: v: lib.elem k cfg.serverNodeNames) nodes))
         ++ lib.optionals (deployType == "aws")

--- a/profiles/consul/common.nix
+++ b/profiles/consul/common.nix
@@ -18,6 +18,23 @@
     ownedChain = "/var/lib/consul/full.pem";
     ownedKey = "/var/lib/consul/cert-key.pem";
   in {
+    # Consul firewall references:
+    #   https://support.hashicorp.com/hc/en-us/articles/1500011608961-Checking-Consul-Network-Connectivity
+    #   https://www.consul.io/docs/install/ports
+    #
+    # Consul ports common to both clients and servers
+    networking.firewall.allowedTCPPorts = [
+      8300  # server rpc
+      8301  # lan serf
+      8302  # wan serf
+      8501  # https required for connect
+      8502  # grpc required for connect
+    ];
+    networking.firewall.allowedUDPPorts = [
+      8301  # lan serf
+      8302  # wan serf
+    ];
+
     services.consul = {
       addresses = { http = lib.mkDefault "127.0.0.1"; };
 
@@ -45,7 +62,7 @@
         region = lib.mkIf (deployType != "prem") config.cluster.region;
       } // (lib.optionalAttrs ((config.currentCoreNode or null) != null) {
         inherit (config.currentCoreNode) domain;
-        instance_type = lib.mkIf (deployType != "prem") config.currentCoreNode.instanceType;
+        instanceType = lib.mkIf (deployType != "prem") config.currentCoreNode.instanceType;
       });
 
       # generate deterministic UUIDs for each node so they can rejoin.

--- a/profiles/consul/common.nix
+++ b/profiles/consul/common.nix
@@ -46,6 +46,7 @@
       primaryDatacenter = if deployType == "aws" then region else datacenter;
       tlsMinVersion = "tls12";
       verifyIncoming = true;
+      verifyIncomingRpc = true;
       verifyOutgoing = true;
       verifyServerHostname = true;
 

--- a/profiles/consul/server.nix
+++ b/profiles/consul/server.nix
@@ -9,6 +9,18 @@
   };
 
   Config = {
+    # Consul firewall references:
+    #   https://support.hashicorp.com/hc/en-us/articles/1500011608961-Checking-Consul-Network-Connectivity
+    #   https://www.consul.io/docs/install/ports
+    #
+    # Consul ports specific to servers
+    networking.firewall.allowedTCPPorts = [
+      8600  # dns
+    ];
+    networking.firewall.allowedUDPPorts = [
+      8600  # dns
+    ];
+
     services.consul = {
       bootstrapExpect = 3;
       addresses = { http = "${config.currentCoreNode.privateIP} 127.0.0.1"; };

--- a/profiles/iso-installer.nix
+++ b/profiles/iso-installer.nix
@@ -1,8 +1,6 @@
 { lib, pkgs, ... }: {
   imports = [ ./auxiliaries/nix.nix ./auxiliaries/ssh.nix ];
 
-  disabledModules = [ "virtualisation/amazon-image.nix" ];
-
   environment = {
     systemPackages = with pkgs; [
       bat
@@ -36,12 +34,7 @@
   time.timeZone = "UTC";
 
   services.chrony.enable = true;
-  networking.hostName = "iso-installer";
-
-  users.extraUsers = {
-    root.initialHashedPassword = lib.mkForce null;
-    nixos.initialHashedPassword = lib.mkForce null;
-  };
+  networking.hostName = lib.mkDefault "iso-installer";
 
   services.getty.helpLine = lib.mkForce ''
     Welcome to the bitte nixOS installer.

--- a/profiles/iso-installer.nix
+++ b/profiles/iso-installer.nix
@@ -1,0 +1,52 @@
+{ lib, pkgs, ... }: {
+  imports = [ ./auxiliaries/nix.nix ./auxiliaries/ssh.nix ];
+
+  disabledModules = [ "virtualisation/amazon-image.nix" ];
+
+  environment = {
+    systemPackages = with pkgs; [
+      bat
+      bind
+      cfssl
+      di
+      fd
+      file
+      gitMinimal
+      htop
+      iptables
+      jq
+      (lib.lowPrio inetutils)
+      lsof
+      ncdu
+      nettools
+      openssl
+      ripgrep
+      sops
+      tcpdump
+      tmux
+      tree
+      vim
+    ];
+  };
+
+  documentation.enable = true;
+  documentation.nixos.enable = true;
+  networking.firewall.allowPing = true;
+  boot.cleanTmpDir = true;
+  time.timeZone = "UTC";
+
+  services.chrony.enable = true;
+  networking.hostName = "iso-installer";
+
+  users.extraUsers = {
+    root.initialHashedPassword = lib.mkForce null;
+    nixos.initialHashedPassword = lib.mkForce null;
+  };
+
+  services.getty.helpLine = lib.mkForce ''
+    Welcome to the bitte nixOS installer.
+    1) Verify network connectivity (ex: ping 8.8.8.8)
+    2) Follow instructions provided by devOps to proceed
+    3) CAUTION: Running any install scripts will WIPE storage drives!
+  '';
+}

--- a/profiles/monitoring.nix
+++ b/profiles/monitoring.nix
@@ -13,7 +13,6 @@ in {
     ./auxiliaries/builder.nix
     ./auxiliaries/docker-registry.nix
     ./auxiliaries/loki.nix
-    ./auxiliaries/oauth.nix
   ];
 
   services.consul.ui = true;

--- a/profiles/monitoring.nix
+++ b/profiles/monitoring.nix
@@ -39,7 +39,7 @@ in {
 
     useDockerRegistry = lib.mkOption {
       type = lib.types.bool;
-      default = false;
+      default = true;
       description = ''
         Enable use of a docker registry backend with a service hosted on the monitoring server.
       '';

--- a/profiles/monitoring.nix
+++ b/profiles/monitoring.nix
@@ -34,6 +34,14 @@ in {
         One, but not both, of `useOauth2Proxy` or `useDigestAuth` options must be true.
       '';
     };
+
+    useDockerRegistry = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enable use of a docker registry backend with a service hosted on the monitoring server.
+      '';
+    };
   };
 
   config = {
@@ -52,6 +60,8 @@ in {
       config.services.grafana.port
       8428  # victoriaMetrics
       9000  # minio
+    ] ++ lib.optionals cfg.useDockerRegistry [
+      config.services.dockerRegistry.port  # dockerRegistry
     ];
 
     services.consul.ui = true;
@@ -62,6 +72,7 @@ in {
     services.loki.enable = true;
     services.grafana.enable = true;
     services.prometheus.enable = false;
+    services.dockerRegistry.enable = cfg.useDockerRegistry;
     services.vulnix.scanClosure = true;
 
     services.victoriametrics = {

--- a/profiles/monitoring.nix
+++ b/profiles/monitoring.nix
@@ -14,6 +14,8 @@ in {
     ./auxiliaries/builder.nix
     ./auxiliaries/docker-registry.nix
     ./auxiliaries/loki.nix
+
+    ../modules/vault-backend.nix
   ];
 
   options.services.monitoring = {
@@ -42,6 +44,15 @@ in {
         Enable use of a docker registry backend with a service hosted on the monitoring server.
       '';
     };
+
+    useVaultBackend = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enable use of a vault TF backend with a service hosted on the monitoring server.
+      '';
+    };
+
   };
 
   config = {
@@ -73,6 +84,7 @@ in {
     services.grafana.enable = true;
     services.prometheus.enable = false;
     services.dockerRegistry.enable = cfg.useDockerRegistry;
+    services.vault-backend.enable = cfg.useVaultBackend;
     services.vulnix.scanClosure = true;
 
     services.victoriametrics = {

--- a/profiles/monitoring.nix
+++ b/profiles/monitoring.nix
@@ -48,6 +48,12 @@ in {
       }
     ];
 
+    networking.firewall.allowedTCPPorts = [
+      config.services.grafana.port
+      8428  # victoriaMetrics
+      9000  # minio
+    ];
+
     services.consul.ui = true;
     services.nomad.enable = false;
     services.minio.enable = true;
@@ -75,7 +81,6 @@ in {
         AUTH_SIGNOUT_REDIRECT_URL = "/oauth2/sign_out";
       } // lib.optionalAttrs cfg.useDigestAuth {
         AUTH_PROXY_HEADER_NAME = "X-WebAuth-User";
-        AUTH_SIGNOUT_REDIRECT_URL = "/digest/sign_out";
       };
       rootUrl = "https://monitoring.${domain}/";
       provision = {

--- a/profiles/monitoring.nix
+++ b/profiles/monitoring.nix
@@ -4,6 +4,7 @@ let
   domain =
     config.${if deployType == "aws" then "cluster" else "currentCoreNode"}.domain;
   isSops = deployType == "aws";
+  cfg = config.services.monitoring;
 in {
   imports = [
     ./common.nix
@@ -15,100 +16,137 @@ in {
     ./auxiliaries/loki.nix
   ];
 
-  services.consul.ui = true;
-  services.nomad.enable = false;
-  services.minio.enable = true;
-  services.vulnix.enable = true;
-  services.victoriametrics.enable = true;
-  services.loki.enable = true;
-  services.grafana.enable = true;
-  services.prometheus.enable = false;
-  services.vulnix.scanClosure = true;
-
-  services.victoriametrics = {
-    retentionPeriod = 12; # months
-  };
-
-  services.grafana = {
-    auth.anonymous.enable = false;
-    analytics.reporting.enable = false;
-    addr = "";
-    domain = "monitoring.${domain}";
-    extraOptions = {
-      AUTH_PROXY_ENABLED = "true";
-      AUTH_PROXY_HEADER_NAME = "X-Auth-Request-Email";
-      AUTH_SIGNOUT_REDIRECT_URL = "/oauth2/sign_out";
-      USERS_AUTO_ASSIGN_ORG_ROLE = "Editor";
-    };
-    rootUrl = "https://monitoring.${domain}/";
-    provision = {
-      enable = true;
-      datasources = [
-        {
-          type = "loki";
-          name = "Loki";
-          url = "http://localhost:3100";
-          jsonData.maxLines = 1000;
-        }
-        {
-          type = "prometheus";
-          name = "VictoriaMetrics";
-          url = "http://localhost:8428";
-        }
-      ];
-
-      dashboards = [{
-        name = "provisioned";
-        options.path = ./monitoring;
-      }];
+  options.services.monitoring = {
+    useOauth2Proxy = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Utilize oauth auth headers provided from traefik on routing.
+        One, but not both, of `useOauth2Proxy` or `useDigestAuth` options must be true.
+      '';
     };
 
-    security.adminPasswordFile = if isSops then "/var/lib/grafana/password"
-                                 else config.age.secrets.grafana-password.path;
+    useDigestAuth = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Utilize digest auth headers provided from traefik on routing.
+        One, but not both, of `useOauth2Proxy` or `useDigestAuth` options must be true.
+      '';
+    };
   };
 
-  services.prometheus = {
-    exporters = {
-      blackbox = {
+  config = {
+
+    assertions = [
+      {
+        assertion = cfg.useOauth2Proxy != cfg.useDigestAuth;
+        message = ''
+          Both `useOauth2Proxy` and `useDigestAuth` options cannot be enabled at the same time.
+          One of `useOauth2Proxy` and `useDigestAuth` options must be enabled.
+        '';
+      }
+    ];
+
+    services.consul.ui = true;
+    services.nomad.enable = false;
+    services.minio.enable = true;
+    services.vulnix.enable = true;
+    services.victoriametrics.enable = true;
+    services.loki.enable = true;
+    services.grafana.enable = true;
+    services.prometheus.enable = false;
+    services.vulnix.scanClosure = true;
+
+    services.victoriametrics = {
+      retentionPeriod = 12; # months
+    };
+
+    services.grafana = {
+      auth.anonymous.enable = false;
+      analytics.reporting.enable = false;
+      addr = "";
+      domain = "monitoring.${domain}";
+      extraOptions = {
+        AUTH_PROXY_ENABLED = "true";
+        USERS_AUTO_ASSIGN_ORG_ROLE = "Editor";
+      } // lib.optionalAttrs cfg.useOauth2Proxy {
+        AUTH_PROXY_HEADER_NAME = "X-Auth-Request-Email";
+        AUTH_SIGNOUT_REDIRECT_URL = "/oauth2/sign_out";
+      } // lib.optionalAttrs cfg.useDigestAuth {
+        AUTH_PROXY_HEADER_NAME = "X-WebAuth-User";
+        AUTH_SIGNOUT_REDIRECT_URL = "/digest/sign_out";
+      };
+      rootUrl = "https://monitoring.${domain}/";
+      provision = {
         enable = true;
-        configFile = pkgs.toPrettyJSON "blackbox-exporter" {
-          modules = {
-            https_2xx = {
-              prober = "http";
-              timeout = "5s";
-              http = { fail_if_not_ssl = true; };
+        datasources = [
+          {
+            type = "loki";
+            name = "Loki";
+            url = "http://localhost:3100";
+            jsonData.maxLines = 1000;
+          }
+          {
+            type = "prometheus";
+            name = "VictoriaMetrics";
+            url = "http://localhost:8428";
+          }
+        ];
+
+        dashboards = [{
+          name = "provisioned";
+          options.path = ./monitoring;
+        }];
+      };
+
+      security.adminPasswordFile = if isSops then "/var/lib/grafana/password"
+                                   else config.age.secrets.grafana-password.path;
+    };
+
+    services.prometheus = {
+      exporters = {
+        blackbox = {
+          enable = true;
+          configFile = pkgs.toPrettyJSON "blackbox-exporter" {
+            modules = {
+              https_2xx = {
+                prober = "http";
+                timeout = "5s";
+                http = { fail_if_not_ssl = true; };
+              };
             };
           };
         };
       };
     };
-  };
 
-  secrets.generate.grafana-password = lib.mkIf isSops ''
-    export PATH="${lib.makeBinPath (with pkgs; [ coreutils sops xkcdpass ])}"
+    secrets.generate.grafana-password = lib.mkIf isSops ''
+      export PATH="${lib.makeBinPath (with pkgs; [ coreutils sops xkcdpass ])}"
 
-    if [ ! -s encrypted/grafana-password.json ]; then
-      xkcdpass \
-      | sops --encrypt --kms '${config.cluster.kms}' /dev/stdin \
-      > encrypted/grafana-password.json
-    fi
-  '';
+      if [ ! -s encrypted/grafana-password.json ]; then
+        xkcdpass \
+        | sops --encrypt --kms '${config.cluster.kms}' /dev/stdin \
+        > encrypted/grafana-password.json
+      fi
+    '';
 
-  secrets.install.grafana-password.script = lib.mkIf isSops ''
-    export PATH="${lib.makeBinPath (with pkgs; [ sops coreutils ])}"
+    secrets.install.grafana-password.script = lib.mkIf isSops ''
+      export PATH="${lib.makeBinPath (with pkgs; [ sops coreutils ])}"
 
-    mkdir -p /var/lib/grafana
+      mkdir -p /var/lib/grafana
 
-    cat ${(toString config.secrets.encryptedRoot) + "/grafana-password.json"} \
-      | sops -d /dev/stdin \
-      > /var/lib/grafana/password
-  '';
+      cat ${(toString config.secrets.encryptedRoot) + "/grafana-password.json"} \
+        | sops -d /dev/stdin \
+        > /var/lib/grafana/password
+    '';
 
-  age.secrets = lib.mkIf (deployType != "aws") {
-    grafana-password = {
-      file = config.age.encryptedRoot + "/grafana/password.age";
-      path = "/var/lib/grafana/grafana-password";
-      mode = "0600";
+    age.secrets = lib.mkIf (deployType != "aws") {
+      grafana-password = {
+        file = config.age.encryptedRoot + "/grafana/password.age";
+        path = "/var/lib/grafana/grafana-password";
+        mode = "0600";
+      };
     };
   };
 }

--- a/profiles/monitoring/consul.json
+++ b/profiles/monitoring/consul.json
@@ -928,7 +928,7 @@
         "handler": 1,
         "message": "Average key-value store commit time over the past hour is > 20 ms.\nThe consul servers may be overloaded or not functioning correctly.",
         "name": "[Consul] KVs apply alert",
-        "noDataState": "alerting",
+        "noDataState": "ok",
         "notifications": []
       },
       "aliasColors": {},

--- a/profiles/nomad/client.nix
+++ b/profiles/nomad/client.nix
@@ -16,12 +16,17 @@
     #   https://www.nomadproject.io/docs/install/production/requirements
     #
     # Nomad ports specific to clients
-    networking.firewall.allowedTCPPortRanges = [
-      {
-        from = cfg.client.min_dynamic_port;
-        to = cfg.client.max_dynamic_port;
-      }
-    ];
+    networking.firewall = {
+      allowedTCPPortRanges = [
+        {
+          from = cfg.client.min_dynamic_port;
+          to = cfg.client.max_dynamic_port;
+        }
+      ];
+
+      # Trust traffic originating from the Nomad bridge where nomad bridge jobs are run
+      trustedInterfaces = [ cfg.client.bridge_network_name ];
+    };
 
     # Used for Consul Connect in clients
     boot.kernel.sysctl = {

--- a/profiles/nomad/client.nix
+++ b/profiles/nomad/client.nix
@@ -9,7 +9,7 @@
 
   Config = let
     deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
-    datacenter = config.currentCoreNode.datacenter or config.currentAwsAutoScalingGroup.datacenter;
+    datacenter = config.currentCoreNode.datacenter or config.cluster.region;
     cfg = config.services.nomad;
   in {
     # Nomad firewall references:

--- a/profiles/nomad/client.nix
+++ b/profiles/nomad/client.nix
@@ -10,7 +10,26 @@
   Config = let
     deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
     datacenter = config.currentCoreNode.datacenter or config.currentAwsAutoScalingGroup.datacenter;
+    cfg = config.services.nomad;
   in {
+    # Nomad firewall references:
+    #   https://www.nomadproject.io/docs/install/production/requirements
+    #
+    # Nomad ports specific to clients
+    networking.firewall.allowedTCPPortRanges = [
+      {
+        from = cfg.client.min_dynamic_port;
+        to = cfg.client.max_dynamic_port;
+      }
+    ];
+
+    # Used for Consul Connect in clients
+    boot.kernel.sysctl = {
+      "net.bridge.bridge-nf-call-arptables" = 1;
+      "net.bridge.bridge-nf-call-ip6tables" = 1;
+      "net.bridge.bridge-nf-call-iptables" = 1;
+    };
+
     services.nomad = {
       client = {
         gc_interval = "12h";
@@ -21,6 +40,17 @@
             "/usr";
           "/etc/passwd" = "/etc/passwd";
         };
+
+        # min_dynamic_port adjusted higher than the 20000 default to avoid collision
+        # with consul's dynamic port range.
+        #
+        # Refs:
+        #   https://www.nomadproject.io/docs/job-specification/network#dynamic-ports
+        #   https://www.consul.io/docs/agent/options#ports
+        #   https://github.com/hashicorp/consul/issues/12253
+        #   https://github.com/hashicorp/nomad/issues/4285
+        min_dynamic_port = 22000;
+        max_dynamic_port = 32000;
       };
 
       datacenter = if deployType == "aws" then config.currentAwsAutoScalingGroup.region else datacenter;

--- a/profiles/nomad/common.nix
+++ b/profiles/nomad/common.nix
@@ -18,6 +18,16 @@
     consulOwnedChain = "/var/lib/consul/full.pem";
     consulOwnedKey = "/var/lib/consul/cert-key.pem";
   in {
+    # Nomad firewall references:
+    #   https://www.nomadproject.io/docs/install/production/requirements
+    #
+    # Nomad ports common to both clients and servers
+    networking.firewall = {
+      allowedTCPPorts = [
+        4646  # http api
+        4647  # rpc
+      ];
+    };
 
     environment.variables = {
       NOMAD_ADDR =
@@ -72,13 +82,6 @@
           "role:nomad"
         ];
       };
-    };
-
-    # Used for Consul Connect.
-    boot.kernel.sysctl = {
-      "net.bridge.bridge-nf-call-arptables" = 1;
-      "net.bridge.bridge-nf-call-ip6tables" = 1;
-      "net.bridge.bridge-nf-call-iptables" = 1;
     };
   };
 

--- a/profiles/nomad/common.nix
+++ b/profiles/nomad/common.nix
@@ -11,7 +11,7 @@
   Config = let
     inherit (config.cluster) region;
     deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
-    datacenter = config.currentCoreNode.datacenter or config.currentAwsAutoScalingGroup.datacenter;
+    datacenter = config.currentCoreNode.datacenter or config.cluster.region;
 
     ownedChain = "/var/lib/nomad/full.pem";
     ownedKey = "/var/lib/nomad/cert-key.pem";

--- a/profiles/nomad/server.nix
+++ b/profiles/nomad/server.nix
@@ -10,7 +10,7 @@
   Config = let
     inherit (config.cluster) nodes region;
     deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
-    datacenter = config.currentCoreNode.datacenter or config.currentAwsAutoScalingGroup.datacenter;
+    datacenter = config.currentCoreNode.datacenter or config.cluster.region;
 
     cfg = config.services.nomad;
   in {

--- a/profiles/nomad/server.nix
+++ b/profiles/nomad/server.nix
@@ -14,6 +14,17 @@
 
     cfg = config.services.nomad;
   in {
+    # Nomad firewall references:
+    #   https://www.nomadproject.io/docs/install/production/requirements
+    #
+    # Nomad ports specific to servers
+    networking.firewall.allowedTCPPorts = [
+      4648  # serf wan
+    ];
+    networking.firewall.allowedUDPPorts = [
+      4648  # serf wan
+    ];
+
     services.nomad = {
       datacenter = if deployType == "aws" then region else datacenter;
 

--- a/profiles/nomad/server.nix
+++ b/profiles/nomad/server.nix
@@ -8,7 +8,7 @@
   };
 
   Config = let
-    inherit (config.cluster) coreNodes premSimNodes region;
+    inherit (config.cluster) nodes region;
     deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
     datacenter = config.currentCoreNode.datacenter or config.currentAwsAutoScalingGroup.datacenter;
 
@@ -21,7 +21,7 @@
         bootstrap_expect = 3;
 
         server_join = {
-          retry_join = (lib.mapAttrsToList (_: v: v.privateIP) (lib.filterAttrs (k: v: lib.elem k cfg.serverNodeNames) (premSimNodes // coreNodes)))
+          retry_join = (lib.mapAttrsToList (_: v: v.privateIP) (lib.filterAttrs (k: v: lib.elem k cfg.serverNodeNames) nodes))
             ++ (lib.optionals (deployType == "aws")
             [ "provider=aws region=${region} tag_key=Nomad tag_value=server" ]);
         };

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -83,6 +83,8 @@ in {
       }
     ];
 
+    networking.firewall.allowedTCPPorts = [ 80 443 ];
+
     services.traefik.enable = true;
     services.consul.ui = true;
 

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -40,6 +40,7 @@ in {
       default = true;
       description = ''
         Apply oauth middleware to the standard UI bitte services.
+        One, but not both, of `useOauth2Proxy` or `useDigestAuth` options must be true.
       '';
     };
 
@@ -48,6 +49,7 @@ in {
       default = false;
       description = ''
         Apply digest auth middleware to the standard UI bitte services.
+        One, but not both, of `useOauth2Proxy` or `useDigestAuth` options must be true.
       '';
     };
 
@@ -70,6 +72,17 @@ in {
   };
 
   config = {
+
+    assertions = [
+      {
+        assertion = cfg.useOauth2Proxy != cfg.useDigestAuth;
+        message = ''
+          Both `useOauth2Proxy` and `useDigestAuth` options cannot be enabled at the same time.
+          One of `useOauth2Proxy` and `useDigestAuth` options must be enabled.
+        '';
+      }
+    ];
+
     services.traefik.enable = true;
     services.consul.ui = true;
 
@@ -329,6 +342,8 @@ in {
             digest-auth = {
               digestAuth = {
                 usersFile = cfg.digestAuthFile;
+                removeHeader = true;
+                headerField= "X-WebAuth-User";
               };
             };
           };

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -1,7 +1,7 @@
 { self, lib, pkgs, config, nodeName, bittelib, hashiTokens, letsencryptCertMaterial, pkiFiles, ... }:
 let
   deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
-  datacenter = config.currentCoreNode.datacenter or config.currentAwsAutoScalingGroup.datacenter;
+  datacenter = config.currentCoreNode.datacenter or config.cluster.region;
   domain = config.${if deployType == "aws" then "cluster" else "currentCoreNode"}.domain;
   cfg = config.services.traefik;
 in {

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -281,7 +281,7 @@ in {
               middlewares = [ ];
               rule = "Host(`docker.${domain}`) && PathPrefix(`/`)";
               service = "docker-registry";
-              tls = true;
+              tls = tlsCfg;
             };
           }) // (lib.optionalAttrs cfg.useOauth2Proxy {
             oauth2-route = {
@@ -306,7 +306,7 @@ in {
               middlewares = [ ];
               rule = "Host(`vbk.${domain}`) && PathPrefix(`/`)";
               service = "vault-backend";
-              tls = true;
+              tls = tlsCfg;
             };
           }));
 

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -55,7 +55,7 @@ in {
 
     useDockerRegistry = lib.mkOption {
       type = lib.types.bool;
-      default = false;
+      default = true;
       description = ''
         Enable use of a docker registry backend with a service hosted on the monitoring server.
       '';

--- a/profiles/vault/client.nix
+++ b/profiles/vault/client.nix
@@ -28,7 +28,7 @@
       }];
     };
 
-    systemd.services.certs-updated = lib.mkIf (deployType == "aws") {
+    systemd.services.certs-updated = {
       wantedBy = [ "multi-user.target" ];
       after = [ "vault-agent.service" ];
       path = with pkgs; [ coreutils curl systemd ];

--- a/profiles/vault/common.nix
+++ b/profiles/vault/common.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }: let
+{ config, lib, pkgs, pkiFiles, ... }: let
 
   Imports = { imports = [
     ./secrets-provisioning/cert-identity.nix
@@ -29,9 +29,10 @@
         header_value = config.cluster.domain;
       } else if cfg.autoAuthMethod == "cert" then {
         name = "vault-agent-${cfg.role}";
-        ca_cert = config.age.secrets.vault-ca.path;
-        client_cert = config.age.secrets.vault-client.path;
-        client_key = config.age.secrets.vault-client-key.path;
+        client_cert = if cfg.role == "core" then pkiFiles.serverCertFile
+                      else pkiFiles.clientCertFile;
+        client_key = if cfg.role == "core" then pkiFiles.serverKeyFile
+                      else pkiFiles.clientKeyFile;
       } else (abort "Unknown vault autoAuthMethod");
     };
   };

--- a/profiles/vault/policies.nix
+++ b/profiles/vault/policies.nix
@@ -68,7 +68,6 @@ in {
       "nomad/creds/*".capabilities = [ r ];
       "pki/cert/ca".capabilities = [ r ];
       "pki/certs".capabilities = [ l ];
-      "pki-consul/*".capabilities = [ s ];
       "pki/issue/*".capabilities = [ c u ];
       "pki/revoke".capabilities = [ c u ];
       "pki/roles/server".capabilities = [ r ];

--- a/profiles/vault/secrets-provisioning/cert-identity.nix
+++ b/profiles/vault/secrets-provisioning/cert-identity.nix
@@ -5,43 +5,43 @@ in {
   age.secrets = lib.mkIf (deployType != "aws") {
     vault-full-server = {
       file = config.age.encryptedRoot + "/ssl/server-full.age";
-      path = "/etc/ssl/certs/server-full.pem";
+      path = pkiFiles.serverCertChainFile;
       mode = "0644";
     };
 
     vault-full-client = {
       file = config.age.encryptedRoot + "/ssl/client-full.age";
-      path = "/etc/ssl/certs/client-full.pem";
+      path = pkiFiles.clientCertChainFile;
       mode = "0644";
     };
 
     vault-ca = {
       file = config.age.encryptedRoot + "/ssl/ca.age";
-      path = "/etc/ssl/certs/ca.pem";
+      path = pkiFiles.vaultCaCertFile;
       mode = "0644";
     };
 
     vault-server = {
       file = config.age.encryptedRoot + "/ssl/server.age";
-      path = "/etc/ssl/certs/server.pem";
+      path = pkiFiles.serverCertFile;
       mode = "0644";
     };
 
     vault-server-key = {
       file = config.age.encryptedRoot + "/ssl/server-key.age";
-      path = "/etc/ssl/certs/server-key.pem";
+      path = pkiFiles.serverKeyFile;
       mode = "0600";
     };
 
     vault-client = {
       file = config.age.encryptedRoot + "/ssl/client.age";
-      path = "/etc/ssl/certs/client.pem";
+      path = pkiFiles.clientCertFile;
       mode = "0644";
     };
 
     vault-client-key = {
       file = config.age.encryptedRoot + "/ssl/client-key.age";
-      path = "/etc/ssl/certs/client-key.pem";
+      path = pkiFiles.clientKeyFile;
       mode = "0600";
     };
   };

--- a/profiles/vault/secrets-provisioning/host-identity.nix
+++ b/profiles/vault/secrets-provisioning/host-identity.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, pkiFiles, ... }: let
 
-  datacenter = config.currentCoreNode.datacenter or config.currentAwsAutoScalingGroup.datacenter;
+  datacenter = config.currentCoreNode.datacenter or config.cluster.region;
 
   reload = service: "${pkgs.systemd}/bin/systemctl try-reload-or-restart ${service}";
   restart = service: "${pkgs.systemd}/bin/systemctl try-restart ${service}";

--- a/profiles/vault/server.nix
+++ b/profiles/vault/server.nix
@@ -15,7 +15,7 @@
   };
 
   Config = let
-    inherit (config.cluster) coreNodes premSimNodes region;
+    inherit (config.cluster) nodes region;
     deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
     datacenter = config.currentCoreNode.datacenter or config.currentAwsAutoScalingGroup.datacenter;
     ownedChain = "/var/lib/vault/full.pem";
@@ -61,8 +61,7 @@
       storage.raft = let
         vcfg = config.services.vault;
         vaultServers =
-          lib.filterAttrs (k: v: lib.elem k vcfg.serverNodeNames)
-          (premSimNodes // coreNodes);
+          lib.filterAttrs (k: v: lib.elem k vcfg.serverNodeNames) nodes;
       in lib.mkDefault {
         retryJoin = lib.mapAttrsToList (_: vaultServer: {
           leaderApiAddr = "https://${vaultServer.privateIP}:8200";

--- a/profiles/vault/server.nix
+++ b/profiles/vault/server.nix
@@ -17,7 +17,7 @@
   Config = let
     inherit (config.cluster) nodes region;
     deployType = config.currentCoreNode.deployType or config.currentAwsAutoScalingGroup.deployType;
-    datacenter = config.currentCoreNode.datacenter or config.currentAwsAutoScalingGroup.datacenter;
+    datacenter = config.currentCoreNode.datacenter or config.cluster.region;
     ownedChain = "/var/lib/vault/full.pem";
     ownedKey = "/var/lib/vault/cert-key.pem";
 

--- a/profiles/vault/server.nix
+++ b/profiles/vault/server.nix
@@ -25,6 +25,18 @@
                     then "${nodeName}.internal"
                     else config.currentCoreNode.privateIP;
   in {
+    # Vault firewall references:
+    #   https://www.vaultproject.io/docs/configuration/listener/tcp
+    #   https://learn.hashicorp.com/tutorials/vault/reference-architecture
+    #
+    # Vault ports specific to servers
+    networking.firewall = {
+      allowedTCPPorts = [
+        8200  # http api
+        8201  # rpc
+      ];
+    };
+
     services.vault-agent = {
       role = "core";
       vaultAddress = "https://127.0.0.1:8200"; # avoid depending on any network (at least for the agent)


### PR DESCRIPTION
This PR builds on the prior merged prem-sim-rebase branch (https://github.com/input-output-hk/bitte/pull/124) and enables prem deployment.

General:
* Prem deployments are done with upstream deploy-rs (`deploy`) instead of `bitte deploy` since the bitte-cli tooling doesn't directly support a prem use case yet
* Deploys using upstream deploy-rs rely on configured ssh config for premNode hostnames
  * ex: `$BITTE_CLUSTER.conf` defn file imported into user ssh config.d
  * hostnames of premNodes are expected to be namespaced in ssh config as `$BITTE_CLUSTER-$NODENAME`
* `hydrate-cluster` policies have been split into base policy and aws policy and are appropriately imported depending on infraType, preserving existing behavior
* Timeserver daemon has been changed from `openntpd` to `chrony` which allows better timesync in envs where initial delta may be high and openntpd won't sync for extended periods
* ISO installer profile has been added for base iso bitte image config

Features - General:
* Proper FW hardening has been added for prem and premSim use case where SGs are not present.  AWS use case still utilizes SGs and existing behavior is preserved.
* Docker registry is now proxied to monitoring via traefik frontend (more below in traefik options)
* Consul dns has a dnsmasq recursor added to enable dnsmasq host references (allowing use of `serverNameAddressing` below)
* Routing is the only machine to use core node consul DNS lookups for consul token reasons; the rest use their own consul localhost DNS for efficiency

Features - Options:
* New `infraTypes` cluster level option added to declare the infra type for the cluster.  Defaults to "aws" to preserve existing behavior.
* New `vbkBackend` cluster level option to specify a non-default vault-backend
* New `role` node level option used for extra role granularity on prem since all machines are non-asgs
* New `primaryInterface` option for applying proper networking to prem nodes.  Defaults to aws appropriate value to preserve existing behavior in aws envs.
* New `serverNodeNames` option available for vault, nomad, consul, can be used to extend a 3 member core cluster to 5. 
 Defaults to core-{1..3} to preserve existing behavior.
* New `serverNameAddressing` option for vault to utilize DNS vs. IP based core member ident, enabling easier core member machine updates (see option description for more)
* New docker daemon log related options to control daemon `logLevel` and log operation `logBlockingMode`, `logMaxBufferSize`
* New additional tls verification controls to support test envs where signed certs are not yet present (consul: `verifyIncomingRpc`, tf: `vbkBackendSkipCertVerification`, docker: `insecureRegistries`)
* New `overrides` option for telegraf module for easier customization since lib.mkIf gets "pushed down" and isn't an option utilize.
* New `useDigestAuth` monitoring option which is grafana user integrated and can be used instead of `useOauth2Proxy`.  Default is `useOauth2Proxy` to preserve existing behavior.
* New `useDockerRegistry` monitoring option.  Defaults to true to preserve existing behavior.
* New `useVaultBackend` monitoring option to host a `$BITTE_CLUSTER`'s own vbk as needed
* New `useOauth2Proxy`, `useDigestAuth`, `useDockerRegistry`, `useVaultBackend`, `digestAuthFile` router profile options, defaulting to preserve existing behavior in proxying services to monitoring.

Fixes:
* Fixed no data alert condition on default bitte consul dashboard for KV alerts.

Potentially breaking changes:
* Default nix profile binary cache `config.cluster.s3Cache` has been removed in favor of other ci options going forward
* Vault mount `pki-consul` and associated vault policies have been removed
* `ntp` user/group and `systemctl-coredump` user removed from common profile

Migration Notes:
* No special migrations required
* Existing behavior should be preserved with defaults of the new options added
* Vault-agent and consul restarts may be required on deployments to core nodes; similar to bitte master behavior already.

Future Improvements TBD:
* Reduction of complexity and logic/branching between "aws" and "prem" `infraTypes`
* Deprecate "aws" + "premSim" concurrent environments as this adds unnecessary complexity
* Deprecate "premSim" envs in favor of pure "prem" types (even if in aws) for further complexity reduction
* Unify secrets management between "aws" and "prem" envs

Testing:
* Deployed to and tested on one each of an aws, prem and premSim env
* machine drv diffs between master and PR tip were compared to minimize unexpected bug introduction