### PR TITLE
Use the instance_types_to_azs module for clients

### DIFF
--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -223,6 +223,18 @@ let
             ];
         };
 
+        requiredAsgInstanceTypes = lib.mkOption {
+          internal = true;
+          readOnly = true;
+          type = with lib.types; listOf str;
+          default =
+            lib.pipe config.cluster.awsAutoScalingGroups [
+              builtins.attrValues
+              (map (lib.attrByPath [ "instanceType" ] null))
+              lib.unique
+            ];
+        };
+
         nodes = lib.mkOption {
           type = with lib.types; attrsOf coreNodeType;
           internal = true;
@@ -967,25 +979,25 @@ let
         vpc = lib.mkOption {
           type = vpcType this.config.uid;
           default = let
+            inherit (this.config) region;
             base = toString (vpcMap.${this.config.region} * 4);
             cidr = "10.${base}.0.0/16";
             atoz = "abcdefghijklmnopqrstuvwxyz";
           in {
-            inherit cidr;
-            region = this.config.region;
+            inherit cidr region;
 
             name = "${cfg.name}-${this.config.region}-asgs";
             subnets = lib.pipe 3 [
               (builtins.genList lib.id)
               (map (idx: lib.nameValuePair
-                (pipe atoz [
+                (lib.pipe atoz [
                   lib.stringToCharacters
                   (lib.flip builtins.elemAt idx)
                 ]) {
                   cidr = net.cidr.subnet 2 idx cidr;
                   availabilityZone =
                     var
-                      "module.instance_types_to_azs.availability_zones[${toString idx}]";
+                      "module.instance_types_to_azs_${region}.availability_zones[${toString idx}]";
                 }))
               lib.listToAttrs
             ];

--- a/modules/terraform/clients.nix
+++ b/modules/terraform/clients.nix
@@ -65,6 +65,13 @@ in {
         alias = awsProviderNameFor region;
       }));
 
+    module = mapAwsAsgVpcs (vpc:
+      lib.nameValuePair "instance_types_to_azs_${vpc.region}" {
+        providers.aws = awsProviderFor vpc.region;
+        source = "${./modules/instance-types-to-azs}";
+        instance_types = config.cluster.requiredAsgInstanceTypes;
+      });
+
     # ---------------------------------------------------------------
     # Networking
     # ---------------------------------------------------------------
@@ -155,6 +162,7 @@ in {
           provider = awsProviderFor vpc.region;
           vpc_id = id "aws_vpc.${vpc.region}";
           cidr_block = subnet.cidr;
+          availability_zone = subnet.availabilityZone;
 
           lifecycle = [{ create_before_destroy = true; }];
 


### PR DESCRIPTION
as well. This mitigates an issue previously observed in core nodes,
where in some regions (notably us-east-1), when an availability zone is
not explicitly provided, AWS arbitrarily picks a zone which does not
necessarily support the requested instance types. This results in
intermittent an intermittent error that's not easily resolvable other
than destroy/plan/apply ad nauseam.

