### PR TITLE
fix: developer sops permissions

### DIFF
--- a/modules/terraform/hydrate-cluster/policies-base.toml
+++ b/modules/terraform/hydrate-cluster/policies-base.toml
@@ -45,7 +45,8 @@ path."sys/policy/*".capabilities = [ "create", "read", "update", "delete", "list
 [vault.developer]
 path."consul/creds/developer".capabilities = [ "read", "update", ] # Allow creating Consul tokens
 path."nomad/creds/developer".capabilities = [ "read", "update", ] # Allow creating Nomad tokens
-path."sops/dev".capabilities = [ "read", "list", ] # Allow to decrypt dev sops secrets
+path."sops/keys/dev".capabilities = ["read", "list"] # Allow to decrypt dev sops secrets
+path."sops/decrypt/dev".capabilities = ["read", "update", "list"]
 
 path."auth/token/lookup-self".capabilities = [ "read", ] # Allow lookup of own tokens
 path."auth/token/renew-self".capabilities = [ "update", ] # Allow self renewing tokens


### PR DESCRIPTION
Without this, Mamba developers couldn't properly decrypt secrets.