### PR TITLE
Avoid some unnecessary resource recreations

### DIFF
--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -105,7 +105,10 @@ in {
           # This indirectly consumes "module.instance_types_to_azs"
           availability_zone = subnet.availabilityZone;
 
-          lifecycle = [{ create_before_destroy = true; }];
+          lifecycle = [{
+            create_before_destroy = true;
+            ignore_changes = [ "availability_zone" ];
+          }];
 
           tags = {
             Cluster = config.cluster.name;


### PR DESCRIPTION
Ignore changes to `ami` for instances and to `availability_zone` for subnets. The latter especially tends to cascade into a tsunami of recreates.