### PR TITLE
Don't destroy and recreate instances when AMI changes

### DIFF
--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -419,6 +419,9 @@ in {
         (lib.mkIf config.cluster.generateSSHKey {
           key_name = var "aws_key_pair.core.key_name";
         })
+        {
+          lifecycle = [{ ignore_changes = [ "ami" ]; }];
+        }
       ]) config.cluster.coreNodes;
 
     # ---------------------------------------------------------------


### PR DESCRIPTION
(this PR breaks down and supersedes https://github.com/input-output-hk/bitte/pull/154)
In most (all?) cases they can/should be updated in place using `bitte deploy`.
In cases where a destroy/recreate cycle is desirable the resource should be explicitly tainted using `terraform taint`.