### PR TITLE
Don't destroy and recreate subnets when their availability zone changes in the terraform config

### DIFF
--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -105,7 +105,10 @@ in {
           # This indirectly consumes "module.instance_types_to_azs"
           availability_zone = subnet.availabilityZone;
 
-          lifecycle = [{ create_before_destroy = true; }];
+          lifecycle = [{
+            create_before_destroy = true;
+            ignore_changes = [ "availability_zone" ];
+          }];
 
           tags = {
             Cluster = config.cluster.name;


### PR DESCRIPTION
A subnet's availability zone can change in the terraform config in a couple of scenarios I can think of:
1) Updating Bitte on an old deployment that was not properly spread across availability zones.
2) (hypothetical) upstream changes to amazon's availability-zone/instance-type support matrix cause the terraform config logic to come up with different subnet->availability zone assignments.

In scenario 1 we may want to follow through with the change set to spread our instances across azs as per best practices, while in scenario 2 it is probably not worth the trouble.

Separating this from #154 so that we can decide on it in isolation.
