### PR TITLE
Fix empty vault token due to race condition

### DIFF
--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -5,7 +5,9 @@ let
 
   kms2region = kms: if kms == null then null else builtins.elemAt (lib.splitString ":" kms) 3;
 
-  relEncryptedFolder = lib.last (builtins.split "-" (toString config.secrets.encryptedRoot));
+  relEncryptedFolder = let
+    encPathStr = if (config.cluster.infraType == "aws") then (toString config.secrets.encryptedRoot) else (toString config.age.encryptedRoot);
+  in lib.last (builtins.split "/nix/store/.{32}-" encPathStr);
 
   merge = lib.foldl' lib.recursiveUpdate { };
 

--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -6,8 +6,8 @@ let
   kms2region = kms: if kms == null then null else builtins.elemAt (lib.splitString ":" kms) 3;
 
   relEncryptedFolder = let
-    encPathStr = if (config.cluster.infraType == "aws") then (toString config.secrets.encryptedRoot) else (toString config.age.encryptedRoot);
-  in lib.last (builtins.split "/nix/store/.{32}-" encPathStr);
+    path = with config; if (cluster.infraType == "aws") then secrets.encryptedRoot else age.encryptedRoot;
+  in lib.last (builtins.split "/nix/store/.{32}-" (toString path));
 
   merge = lib.foldl' lib.recursiveUpdate { };
 

--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -5,6 +5,8 @@ let
 
   kms2region = kms: if kms == null then null else builtins.elemAt (lib.splitString ":" kms) 3;
 
+  relEncryptedFolder = lib.last (builtins.split "-" (toString config.secrets.encryptedRoot));
+
   merge = lib.foldl' lib.recursiveUpdate { };
 
   # without zfs
@@ -110,41 +112,27 @@ let
       fi # manual provisioning
     '';
 
+  sshArgs = "-C -oConnectTimeout=5 -oUserKnownHostsFile=/dev/null -oNumberOfPasswordPrompts=0 -oServerAliveInterval=60 -oControlPersist=600 -oStrictHostKeyChecking=no -i ./secrets/ssh-${cfg.name}";
+  ssh = "${pkgs.openssh}/bin/ssh ${sshArgs}";
+  scp = "${pkgs.openssh}/bin/scp ${sshArgs}";
+
   localProvisionerDefaultCommand = ip:
     let
       nixConf = ''
         experimental-features = nix-command flakes
       '';
       newKernelVersion = config.boot.kernelPackages.kernel.version;
+      sshTarget = "root@${ip}";
     in ''
       set -euo pipefail
-
-      echo
-      echo Waiting for ssh to come up on port 22 ...
-      while [ -z "$(
-        ${pkgs.socat}/bin/socat \
-          -T2 stdout \
-          tcp:${ip}:22,connect-timeout=2,readbytes=1 \
-          2>/dev/null
-      )" ]
-      do
-          printf " ."
-          sleep 5
-      done
 
       sleep 1
 
       echo
       echo Waiting for host to become ready ...
-      ${pkgs.openssh}/bin/ssh -C \
-        -oUserKnownHostsFile=/dev/null \
-        -oNumberOfPasswordPrompts=0 \
-        -oServerAliveInterval=60 \
-        -oControlPersist=600 \
-        -oStrictHostKeyChecking=accept-new \
-        -i ./secrets/ssh-${cfg.name} \
-        root@${ip} \
-        "until grep true /etc/ready &>/dev/null; do sleep 1; done 2>/dev/null"
+      until ${ssh} ${sshTarget} -- grep true /etc/ready &>/dev/null; do
+        sleep 1
+      done
 
       sleep 1
 
@@ -176,19 +164,41 @@ let
 
       echo
       echo Rebooting the host to load eventually newer kernels ...
-      timeout 5 ${pkgs.openssh}/bin/ssh -C \
-        -oUserKnownHostsFile=/dev/null \
-        -oNumberOfPasswordPrompts=0 \
-        -oServerAliveInterval=60 \
-        -oControlPersist=600 \
-        -oStrictHostKeyChecking=accept-new \
-        -i ./secrets/ssh-${cfg.name} \
-        root@${ip} \
+      ${ssh} ${sshTarget} -- \
         "if [ \"$(cat /proc/sys/kernel/osrelease)\" != \"${newKernelVersion}\" ]; then \
         ${pkgs.systemd}/bin/systemctl kexec \
         || (echo Rebooting instead ... && ${pkgs.systemd}/bin/systemctl reboot) ; fi" \
       || true
     '';
+
+  localProvisionerBootstrapperCommand = ip: let
+    sshTarget = "root@${ip}";
+    sopsEncrypt =
+      "${pkgs.sops}/bin/sops --encrypt --input-type json --kms '${cfg.kms}' /dev/stdin";
+  in ''
+    if ! test -f ${relEncryptedFolder}/vault.enc.json; then
+      echo
+      echo Waiting for bootstrapping on core-1 to finish for vault /var/lib/vault/vault.enc.json ...
+      while ! ${ssh} ${sshTarget} -- test -f /var/lib/vault/vault.enc.json &>/dev/null; do
+        sleep 5
+      done
+      echo ... found /var/lib/vault/vault.enc.json
+      secret="$(${ssh} ${sshTarget} -- cat /var/lib/vault/vault.enc.json)"
+      echo "$secret" > ${relEncryptedFolder}/vault.enc.json
+      ${pkgs.git}/bin/git add ${relEncryptedFolder}/vault.enc.json
+    fi
+    if ! test -f ${relEncryptedFolder}/nomad.bootstrap.enc.json; then
+      echo
+      echo Waiting for bootstrapping on core-1 to finish for nomad /var/lib/nomad/bootstrap.token ...
+      while ! ${ssh} ${sshTarget} -- test -f /var/lib/nomad/bootstrap.token &>/dev/null; do
+        sleep 5
+      done
+      echo ... found /var/lib/nomad/bootstrap.token
+      secret="$(${ssh} ${sshTarget} -- cat /var/lib/nomad/bootstrap.token)"
+      echo "{}" | ${pkgs.jq}/bin/jq ".token = \"$secret\"" | ${sopsEncrypt} > ${relEncryptedFolder}/nomad.bootstrap.enc.json
+      ${pkgs.git}/bin/git add ${relEncryptedFolder}/nomad.bootstrap.enc.json
+    fi
+  '';
 
   cfg = config.cluster;
 
@@ -855,7 +865,10 @@ let
 
         localProvisioner = lib.mkOption {
           type = with lib.types; localExecType;
-          default = { protoCommand = localProvisionerDefaultCommand; };
+          default = {
+            protoCommand = localProvisionerDefaultCommand;
+            bootstrapperCommand = localProvisionerBootstrapperCommand;
+          };
         };
 
         instanceType = lib.mkOption { type = with lib.types; str; };
@@ -929,7 +942,18 @@ let
   localExecType = with lib.types;
     submodule {
       options = {
-        protoCommand = lib.mkOption { type = with lib.types; functionTo str; };
+        protoCommand = lib.mkOption {
+          type = with lib.types; functionTo str;
+          description = "Provisioner command to be applied to all nodes";
+        };
+
+        bootstrapperCommand = lib.mkOption {
+          type = with lib.types; nullOr (functionTo str);
+          default = null;
+          description = ''
+            Provisioner command to apply only to the first node, when applicable.
+          '';
+        };
 
         workingDir = lib.mkOption {
           type = with lib.types; nullOr path;

--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -395,7 +395,7 @@ in {
                   if ! test -f ${relEncryptedFolder}/vault.enc.json; then
                     echo
                     echo Waiting for bootstrapping on core-1 to finish for vault /var/lib/vault/vault.enc.json ...
-                    while ! ${ssh} -- test -f /var/lib/vault/vault.enc.json; do
+                    while ! ${ssh} -- test -f /var/lib/vault/vault.enc.json &>/dev/null; do
                       sleep 5
                     done
                     echo ... found /var/lib/vault/vault.enc.json

--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -324,7 +324,7 @@ in {
             {
               local-exec = let
                 command =
-                  coreNode.localProvisioner.protoCommand publicIP;
+                  "${coreNode.localProvisioner.protoCommand} ${publicIP}";
               in {
                 inherit command;
                 inherit (coreNode.localProvisioner) interpreter environment;
@@ -334,7 +334,7 @@ in {
             (lib.optionalAttrs (name == "core-1") {
               local-exec = let
                 command =
-                  coreNode.localProvisioner.bootstrapperCommand publicIP;
+                  "${coreNode.localProvisioner.bootstrapperCommand} ${publicIP}";
               in {
                 inherit command;
                 inherit (coreNode.localProvisioner) interpreter environment;

--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -395,7 +395,9 @@ in {
                   if ! test -f ${relEncryptedFolder}/vault.enc.json; then
                     echo
                     echo Waiting for bootstrapping on core-1 to finish for vault /var/lib/vault/vault.enc.json ...
-                    ${ssh} -- 'while ! test -f /var/lib/vault/vault.enc.json; do sleep 5; done'
+                    while ! ${ssh} -- test -f /var/lib/vault/vault.enc.json; do
+                      sleep 5
+                    done
                     echo ... found /var/lib/vault/vault.enc.json
                     secret="$(${ssh} cat /var/lib/vault/vault.enc.json)"
                     echo "$secret" > ${relEncryptedFolder}/vault.enc.json

--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -12,15 +12,6 @@ let
     To utilize the core TF attr, the cluster config parameter `infraType`
     must either "aws" or "premSim".
   '');
-  sopsEncrypt =
-    "${pkgs.sops}/bin/sops --encrypt --input-type json --kms '${config.cluster.kms}' /dev/stdin";
-
-  sopsDecrypt = path:
-    # NB: we can't work on store paths that don't yet exist before they are generated
-    assert lib.assertMsg (builtins.isString path) "sopsDecrypt: path must be a string ${toString path}";
-    "${pkgs.sops}/bin/sops --decrypt --input-type json ${path}";
-
-  relEncryptedFolder = lib.last (builtins.split "-" (toString config.secrets.encryptedRoot));
 
 in {
   tf.core.configuration = lib.mkIf infraTypeCheck {
@@ -321,31 +312,7 @@ in {
             lib.mkIf (coreNode.ebsOptimized != null) coreNode.ebsOptimized;
 
           provisioner = let
-            sshArgs = "-C -oConnectTimeout=5 -oUserKnownHostsFile=/dev/null -oNumberOfPasswordPrompts=0 -oServerAliveInterval=60 -oControlPersist=600 -oStrictHostKeyChecking=no -i ./secrets/ssh-${config.cluster.name}";
             publicIP = var "aws_eip.${coreNode.uid}.public_ip";
-            target = "root@${publicIP}";
-            ssh = "${pkgs.openssh}/bin/ssh ${sshArgs} ${target}";
-            scp = "${pkgs.openssh}/bin/scp ${sshArgs} ";
-            waitForSsh' = ''
-              echo Waiting for ssh to come up on port 22 ...
-              while test -z "$(
-                ${pkgs.socat}/bin/socat \
-                  -T2 stdout \
-                  tcp:${var "aws_eip.${coreNode.uid}.public_ip"}:22,connect-timeout=2,readbytes=1 \
-                  2>/dev/null
-              )"
-              do
-                  printf " ."
-                  sleep 5
-              done
-            '';
-            waitForSsh = ''
-              echo Waiting for ssh to come up on port 22 ...
-              while ! ${ssh} true; do
-                  printf " ."
-                  sleep 5
-              done
-            '';
           in [
             {
               local-exec = {
@@ -364,35 +331,14 @@ in {
                 working_dir = coreNode.localProvisioner.workingDir;
               };
             }
-            (lib.optional (name == "core-1") {
-              local-exec = {
-                command = ''
-                  echo
-                  ${waitForSsh}
-
-                  sleep 1
-
-                  if ! test -f ${relEncryptedFolder}/vault.enc.json; then
-                    echo
-                    echo Waiting for bootstrapping on core-1 to finish for vault /var/lib/vault/vault.enc.json ...
-                    while ! ${ssh} -- test -f /var/lib/vault/vault.enc.json &>/dev/null; do
-                      sleep 5
-                    done
-                    echo ... found /var/lib/vault/vault.enc.json
-                    secret="$(${ssh} cat /var/lib/vault/vault.enc.json)"
-                    echo "$secret" > ${relEncryptedFolder}/vault.enc.json
-                    ${pkgs.git}/bin/git add ${relEncryptedFolder}/vault.enc.json
-                  fi
-                  if ! test -f ${relEncryptedFolder}/nomad.bootstrap.enc.json; then
-                    echo
-                    echo Waiting for bootstrapping on core-1 to finish for nomad /var/lib/nomad/bootstrap.token ...
-                    ${ssh} -- 'while ! test -f /var/lib/nomad/bootstrap.token; do sleep 5; done'
-                    echo ... found /var/lib/nomad/bootstrap.token
-                    secret="$(${ssh} -- cat /var/lib/nomad/bootstrap.token)"
-                    echo "{}" | ${pkgs.jq}/bin/jq ".token = \"$secret\"" | ${sopsEncrypt} > ${relEncryptedFolder}/nomad.bootstrap.enc.json
-                    ${pkgs.git}/bin/git add ${relEncryptedFolder}/nomad.bootstrap.enc.json
-                  fi
-                '';
+            (lib.optionalAttrs (name == "core-1") {
+              local-exec = let
+                command =
+                  coreNode.localProvisioner.bootstrapperCommand publicIP;
+              in {
+                inherit command;
+                inherit (coreNode.localProvisioner) interpreter environment;
+                working_dir = coreNode.localProvisioner.workingDir;
               };
             })
           ];


### PR DESCRIPTION
A `while` loop wrapped in an ssh call never gets invoked if the ssh call is run before the instance is accepting ssh connections. In that case we would get a `connection refused` and proceed to the next line in the bootstrapper provisioner script due to no `set -e`.