### PR TITLE
Clients Happier Path

### DIFF
--- a/modules/terraform/clients.nix
+++ b/modules/terraform/clients.nix
@@ -395,7 +395,7 @@ in {
       # deploy for core role
       inherit (config.cluster.iam.roles.client) uid;
     in {
-      "${uid}".name = uid;
+      "${uid}".name = "core-${uid}";
     };
 
     data.aws_iam_policy_document = let

--- a/modules/terraform/clients.nix
+++ b/modules/terraform/clients.nix
@@ -192,6 +192,16 @@ in {
             id "aws_vpc_peering_connection.${vpc.region}";
         }));
 
+    resource.aws_s3_bucket_object = lib.flip lib.mapAttrs' config.cluster.awsAutoScalingGroups (name: group:
+      lib.nameValuePair "${name}-flake" rec {
+        bucket = config.cluster.s3Bucket;
+        key    = with config; "infra/secrets/${cluster.name}/${cluster.kms}/source/${name}-source.tar.xz";
+        etag  = var ''filemd5("${source}")'';
+        source = "${pkgs.runCommand "source.tar.xz" {} ''
+          tar cvf $out -C ${config.cluster.flakePath} .
+        ''}";
+      });
+
     resource.aws_subnet = mapAwsAsgVpcs (vpc:
       lib.flip lib.mapAttrsToList vpc.subnets (suffix: subnet:
         lib.nameValuePair "${vpc.region}-${suffix}" {
@@ -316,7 +326,7 @@ in {
         lib.nameValuePair vpc.region {
           provider = awsProviderFor vpc.region;
           vpc_peering_connection_id =
-            id "aws_vpc_peering_connection.${vpc.region}";
+            id "aws_vpc_peering_connection_accepter.${vpc.region}";
 
           requester = {allow_remote_vpc_dns_resolution = true;};
         });
@@ -334,9 +344,8 @@ in {
       requesterMeshPeeringOptions = mapAwsAsgVpcPeers (link:
         lib.nameValuePair "${link.connector}-connect-${link.accepter}" {
           provider = awsProviderFor link.connector;
-          vpc_peering_connection_id =
-            id
-            "aws_vpc_peering_connection.${link.connector}-connect-${link.accepter}";
+          vpc_peering_connection_id = id
+            "aws_vpc_peering_connection_accepter.${link.accepter}-accept-${link.connector}";
 
           requester = {allow_remote_vpc_dns_resolution = true;};
         });
@@ -378,9 +387,16 @@ in {
       lib.nameValuePair group.uid {
         name = group.uid;
         inherit (group.iam.instanceProfile) path;
-        role = group.iam.instanceProfile.role.tfName;
-        lifecycle = [{create_before_destroy = true;}];
+        role = var "data.aws_iam_role.${config.cluster.iam.roles.client.uid}.name";
+        lifecycle = [{ create_before_destroy = true; }];
       });
+
+    data.aws_iam_role = let
+      # deploy for core role
+      inherit (config.cluster.iam.roles.client) uid;
+    in {
+      "${uid}".name = uid;
+    };
 
     data.aws_iam_policy_document = let
       # deploy for client role
@@ -395,19 +411,7 @@ in {
               inherit (policy) condition;
             });
         };
-    in
-      lib.listToAttrs (lib.mapAttrsToList op role.policies);
-
-    resource.aws_iam_role = let
-      # deploy for client role
-      role = config.cluster.iam.roles.client;
-    in {
-      "${role.uid}" = {
-        name = role.uid;
-        assume_role_policy = role.assumePolicy.tfJson;
-        lifecycle = [{create_before_destroy = true;}];
-      };
-    };
+    in lib.mapAttrs' op role.policies;
 
     resource.aws_iam_role_policy = let
       # deploy for client role
@@ -415,11 +419,10 @@ in {
       op = policyName: policy:
         lib.nameValuePair policy.uid {
           name = policy.uid;
-          role = role.id;
+          role = id "data.aws_iam_role.${role.uid}";
           policy = var "data.aws_iam_policy_document.${policy.uid}.json";
         };
-    in
-      lib.listToAttrs (lib.mapAttrsToList op role.policies);
+    in lib.mapAttrs' op role.policies;
 
     resource.aws_security_group =
       lib.flip lib.mapAttrsToList config.cluster.awsAutoScalingGroups

--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -228,7 +228,7 @@ in {
       inherit (config.cluster.iam.roles) client core;
     in {
       "${client.uid}" = {
-        name = client.uid;
+        name = "core-${client.uid}";
         assume_role_policy = client.assumePolicy.tfJson;
         lifecycle = [{ create_before_destroy = true; }];
       };

--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -225,12 +225,17 @@ in {
 
     resource.aws_iam_role = let
       # deploy for core role
-      role = config.cluster.iam.roles.core;
+      inherit (config.cluster.iam.roles) client core;
     in {
-      "${role.uid}" = {
-        name = role.uid;
-        assume_role_policy = role.assumePolicy.tfJson;
-        lifecycle = [{create_before_destroy = true;}];
+      "${client.uid}" = {
+        name = client.uid;
+        assume_role_policy = client.assumePolicy.tfJson;
+        lifecycle = [{ create_before_destroy = true; }];
+      };
+      "${core.uid}" = {
+        name = core.uid;
+        assume_role_policy = core.assumePolicy.tfJson;
+        lifecycle = [{ create_before_destroy = true; }];
       };
     };
 

--- a/profiles/client.nix
+++ b/profiles/client.nix
@@ -19,7 +19,6 @@ in {
     ./auxiliaries/reaper.nix
   ];
 
-  services.s3-upload-flake.enable = deployType == "aws";
   services.zfs-client-options.enable = deployType == "aws";
 
   services.telegraf.extraConfig.global_tags.role = "consul-client";

--- a/profiles/glusterfs/client.nix
+++ b/profiles/glusterfs/client.nix
@@ -14,15 +14,15 @@ in {
     path = with pkgs; [nettools];
   };
 
-  fileSystems."/mnt/gv0" = lib.mkIf cfg.enable {
-    device = "glusterd.service.consul:/gv0";
-    fsType = "glusterfs";
-  };
-
-  systemd.services."mnt-gv0.mount" = lib.mkIf cfg.enable {
-    after = ["consul.service"];
-    wants = ["consul.service"];
-  };
+  systemd.mounts = [
+    (lib.mkIf cfg.enable {
+      after = [ "consul.service" "dnsmasq.service" ];
+      wants = [ "consul.service" "dnsmasq.service" ];
+      what = "glusterd.service.consul:/gv0";
+      where = "/mnt/gv0";
+      type = "glusterfs";
+    })
+  ];
 
   systemd.services.nomad = lib.mkIf cfg.enable {
     after = ["mnt-gv0.mount"];


### PR DESCRIPTION
This includes the following changes/fixes:
- When iterating over retrieved availability zone lists, use terraform's `element()` function instead of the `splat` syntax to make the iteration wrap around instead of error out when the index is out of bounds. This was necessary for me to be able to deploy the sandbox cores in the Canadian region which did not have the required instance types available in 3 different azs but only in 2.
- Remove the need to `Bitte ssh core-1 -- systemctl restart vault-setup` after deploying the clients. This is has been achieved by creating the relevant role in the core phase, so that it already exists when `vault-setup.service` runs initially on `core-1`. The corresponding policy is still created and attached during the `clients` terraform config (where the role is now retrieved via a `data` source).
- Upload the flake tarballs during the `clients`' terraform run, instead of a systemd service running on the clients. That way it is always available even on the very first boot.
- Fix timeout during initial `nixes-rebuild` on the clients (~5 minutes, imposed by `amazon-init`). this has been achieved by wrapping most of the `user data` script in a heredoc, writing it into `/etc` and then executing it using `systemd-run` as an ad-hoc unit.
- Fix glusterfs mount on clients. this was configured incorrectly: `systemd.services."mnt-gv0.mount"` instead of `systemd.mounts = [ { ... } ... ];` also made it run only after `dnsmasq` to ensure that `*.consul` dns resolution is available.

The above resulted in being able to run `plan/apply clients` and watch them magically appear in the `clients` section of the nomad web ui without any additional intervention. I legit cried 🤣

## Migration

```
nix run .#clusters.$BITTE_CLUSTER.tf.core.plan
nix run .#clusters.$BITTE_CLUSTER.tf.core.apply
nix run .#clusters.$BITTE_CLUSTER.tf.clients.plan
nix run .#clusters.$BITTE_CLUSTER.tf.clients.apply
```
