### PR TITLE
fix: resolve unexpected oci restarts due to nixpkgs bump affecting dockerd

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1133,6 +1133,22 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-docker": {
+      "locked": {
+        "lastModified": 1652739558,
+        "narHash": "sha256-znGkjGugajqF/sFS+H4+ENmGTaVPFE0uu1JjQZJLEaQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ff691ed9ba21528c1b4e034f36a04027e4522c58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ff691ed9ba21528c1b4e034f36a04027e4522c58",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -1884,6 +1900,7 @@
         "n2c": "n2c",
         "nix": "nix_4",
         "nixpkgs": "nixpkgs_21",
+        "nixpkgs-docker": "nixpkgs-docker",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "nomad": "nomad_2",
         "nomad-driver-nix": "nomad-driver-nix_2",

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
   inputs.capsules.url = "github:input-output-hk/devshell-capsules";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
+    nixpkgs-docker.url = "github:nixos/nixpkgs/ff691ed9ba21528c1b4e034f36a04027e4522c58";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     nix.url = "github:nixos/nix/2.8.1";


### PR DESCRIPTION
* Restarting the docker daemon causes OCI job restarts
* Pinning docker avoids unexpected metal deploy OCI job disruption when nixpkgs is bumped
* Containerd pkg also version pinned to avoid version mismatches (both pkg binaries run in the same system service namespace and are version matched)
* This PRs pin brings docker/containerd back to 20.10.15 which is where it was prior to the monitoring-update PRs nixpkgs-unstable bump