### PR TITLE
bump: nomad 1.2.6 -> 1.3.2, move to pkg decl w/ patch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -936,22 +936,6 @@
     "lowdown-src_5": {
       "flake": false,
       "locked": {
-        "lastModified": 1598695561,
-        "narHash": "sha256-gyH/5j+h/nWw0W8AcR2WKvNBUsiQ7QuxqSJNXAwV+8E=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "1705b4a26fbf065d9574dce47a94e8c7c79e052f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "lowdown-src_6": {
-      "flake": false,
-      "locked": {
         "lastModified": 1633514407,
         "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
         "owner": "kristapsdz",
@@ -1068,26 +1052,7 @@
     "nix_5": {
       "inputs": {
         "lowdown-src": "lowdown-src_5",
-        "nixpkgs": "nixpkgs_22"
-      },
-      "locked": {
-        "lastModified": 1604400356,
-        "narHash": "sha256-PX1cSYv0Y6I2tidcuEwJTo8X5vAvf9vjdfHO51LD/J0=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "cf82e14712b3be881b7c880468cd5486e8934638",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix_6": {
-      "inputs": {
-        "lowdown-src": "lowdown-src_6",
-        "nixpkgs": "nixpkgs_24",
+        "nixpkgs": "nixpkgs_22",
         "nixpkgs-regression": "nixpkgs-regression_4"
       },
       "locked": {
@@ -1447,37 +1412,6 @@
     },
     "nixpkgs_22": {
       "locked": {
-        "lastModified": 1602702596,
-        "narHash": "sha256-fqJ4UgOb4ZUnCDIapDb4gCrtAah5Rnr2/At3IzMitig=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ad0d20345219790533ebe06571f82ed6b034db31",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-20.09-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_23": {
-      "locked": {
-        "lastModified": 1638887115,
-        "narHash": "sha256-emjtIeqyJ84Eb3X7APJruTrwcfnHQKs55XGljj62prs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1bd4bbd49bef217a3d1adea43498270d6e779d65",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-21.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_24": {
-      "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
         "owner": "NixOS",
@@ -1491,7 +1425,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_25": {
+    "nixpkgs_23": {
       "locked": {
         "lastModified": 1641909823,
         "narHash": "sha256-Uxo+Wm6c/ijNhaJlYtFLJG9mh75FYZaBreMC2ZE0nEY=",
@@ -1507,7 +1441,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_26": {
+    "nixpkgs_24": {
       "locked": {
         "lastModified": 1647350163,
         "narHash": "sha256-OcMI+PFEHTONthXuEQNddt16Ml7qGvanL3x8QOl2Aao=",
@@ -1523,7 +1457,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_27": {
+    "nixpkgs_25": {
       "locked": {
         "lastModified": 1644525281,
         "narHash": "sha256-D3VuWLdnLmAXIkooWAtbTGSQI9Fc1lkvAr94wTxhnTU=",
@@ -1539,7 +1473,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_28": {
+    "nixpkgs_26": {
       "locked": {
         "lastModified": 1653117584,
         "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
@@ -1710,9 +1644,9 @@
       "inputs": {
         "devshell": "devshell_4",
         "inclusive": "inclusive_4",
-        "nix": "nix_6",
-        "nixpkgs": "nixpkgs_25",
-        "utils": "utils_9"
+        "nix": "nix_5",
+        "nixpkgs": "nixpkgs_23",
+        "utils": "utils_8"
       },
       "locked": {
         "lastModified": 1648029666,
@@ -1753,8 +1687,8 @@
       "inputs": {
         "devshell": "devshell_5",
         "inclusive": "inclusive_5",
-        "nixpkgs": "nixpkgs_26",
-        "utils": "utils_10"
+        "nixpkgs": "nixpkgs_24",
+        "utils": "utils_9"
       },
       "locked": {
         "lastModified": 1652806053,
@@ -1768,27 +1702,6 @@
         "owner": "input-output-hk",
         "repo": "nomad-follower",
         "rev": "20cd9681568586df43ecd1d5b1a476b16b9b1789",
-        "type": "github"
-      }
-    },
-    "nomad_2": {
-      "inputs": {
-        "nix": "nix_5",
-        "nixpkgs": "nixpkgs_23",
-        "utils": "utils_8"
-      },
-      "locked": {
-        "lastModified": 1648128770,
-        "narHash": "sha256-iv5Zjddi28OJH7Kh8/oGJ0k32PQXiY+56qXKiLIxSEI=",
-        "owner": "input-output-hk",
-        "repo": "nomad",
-        "rev": "beb504f6c8bd832e1d4509e4104187774b8ecfc0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release-1.2.6",
-        "repo": "nomad",
         "type": "github"
       }
     },
@@ -1870,7 +1783,7 @@
       "inputs": {
         "agenix": "agenix_5",
         "flake-utils": "flake-utils_7",
-        "nixpkgs": "nixpkgs_27",
+        "nixpkgs": "nixpkgs_25",
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
@@ -1902,14 +1815,13 @@
         "nixpkgs": "nixpkgs_21",
         "nixpkgs-docker": "nixpkgs-docker",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
-        "nomad": "nomad_2",
         "nomad-driver-nix": "nomad-driver-nix_2",
         "nomad-follower": "nomad-follower_2",
         "ops-lib": "ops-lib_2",
         "ragenix": "ragenix_3",
         "std": "std",
         "terranix": "terranix_2",
-        "utils": "utils_11"
+        "utils": "utils_10"
       }
     },
     "rust-analyzer-src": {
@@ -2064,7 +1976,7 @@
     "std": {
       "inputs": {
         "devshell": "devshell_6",
-        "nixpkgs": "nixpkgs_28",
+        "nixpkgs": "nixpkgs_26",
         "yants": "yants_2"
       },
       "locked": {
@@ -2253,21 +2165,6 @@
     },
     "utils_10": {
       "locked": {
-        "lastModified": 1633020561,
-        "narHash": "sha256-4uAiRqL9nP3d/NQ8VBqjQ5iZypHaM+X/FyWpXVXkwTA=",
-        "owner": "kreisys",
-        "repo": "flake-utils",
-        "rev": "2923532a276a5595ee64376ec1b3db6ed8503c52",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kreisys",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_11": {
-      "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
@@ -2373,15 +2270,15 @@
     },
     "utils_8": {
       "locked": {
-        "lastModified": 1601282935,
-        "narHash": "sha256-WQAFV6sGGQxrRs3a+/Yj9xUYvhTpukQJIcMbIi7LCJ4=",
-        "owner": "numtide",
+        "lastModified": 1633020561,
+        "narHash": "sha256-4uAiRqL9nP3d/NQ8VBqjQ5iZypHaM+X/FyWpXVXkwTA=",
+        "owner": "kreisys",
         "repo": "flake-utils",
-        "rev": "588973065fce51f4763287f0fda87a174d78bf48",
+        "rev": "2923532a276a5595ee64376ec1b3db6ed8503c52",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
+        "owner": "kreisys",
         "repo": "flake-utils",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,6 @@
     utils.url = "github:numtide/flake-utils";
     blank.url = "github:divnix/blank";
 
-    nomad.url = "github:input-output-hk/nomad/release-1.2.6";
     nomad-driver-nix.url = "github:input-output-hk/nomad-driver-nix";
 
     # Vector >= 0.20.0 versions require nomad-follower watch-config format fix

--- a/overlay.nix
+++ b/overlay.nix
@@ -52,7 +52,7 @@ in
       haproxy-auth-request = prev.callPackage ./pkgs/haproxy-auth-request.nix {};
       haproxy-cors = prev.callPackage ./pkgs/haproxy-cors.nix {};
       mill = prev.callPackage ./pkgs/mill.nix {};
-      nomad = inputs.nomad.defaultPackage.${final.system};
+      nomad = prev.callPackage ./pkgs/nomad.nix {buildGoModule = prev.buildGo117Module;};
       nomad-autoscaler = prev.callPackage ./pkgs/nomad-autoscaler.nix {};
       nomad-follower = inputs.nomad-follower.defaultPackage.${prev.system};
       oauth2-proxy = final.callPackage ./pkgs/oauth2_proxy.nix {};
@@ -62,10 +62,10 @@ in
       spire = prev.callPackage ./pkgs/spire.nix {};
       spire-server = spire.server;
       spire-systemd-attestor = prev.callPackage ./pkgs/spire-systemd-attestor.nix {};
-      traefik = prev.callPackage ./pkgs/traefik.nix {buildGoModule = final.buildGo117Module;};
+      traefik = prev.callPackage ./pkgs/traefik.nix {buildGoModule = prev.buildGo117Module;};
       vault-backend = final.callPackage ./pkgs/vault-backend.nix {};
       vault-bin = prev.callPackage ./pkgs/vault-bin.nix {};
-      victoriametrics = prev.callPackage ./pkgs/victoriametrics.nix {buildGoModule = final.buildGo117Module;};
+      victoriametrics = prev.callPackage ./pkgs/victoriametrics.nix {buildGoModule = prev.buildGo117Module;};
 
       scaler-guard = let
         deps = with final; [awscli bash curl jq nomad];

--- a/pkgs/nomad.nix
+++ b/pkgs/nomad.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nixosTests,
+}:
+buildGoModule rec {
+  pname = "nomad";
+  version = "1.3.2";
+
+  subPackages = ["."];
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-GJul7slXNLEp+3l3OQ43ALVH3IscoCDDL7FG2UFtLG8=";
+  };
+
+  patches = [
+    ./nomad/nomad-exec-nix-driver.patch
+  ];
+
+  vendorSha256 = "sha256-MqtkYHGIgeCFnbwE09xHgPMuJBSVHL0hB9RbwNX+K40=";
+
+  # ui:
+  #  Nomad release commits include the compiled version of the UI, but the file
+  #  is only included if we build with the ui tag.
+  tags = ["ui"];
+
+  passthru.tests.nomad = nixosTests.nomad;
+
+  meta = with lib; {
+    homepage = "https://www.nomadproject.io/";
+    description = "A Distributed, Highly Available, Datacenter-Aware Scheduler";
+    platforms = platforms.unix;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [rushmorem pradeepchhetri endocrimes maxeaubrey techknowlogick];
+  };
+}

--- a/pkgs/nomad/nomad-exec-nix-driver.patch
+++ b/pkgs/nomad/nomad-exec-nix-driver.patch
@@ -1,0 +1,336 @@
+diff --git c/client/allocrunner/taskrunner/nix_hook.go i/client/allocrunner/taskrunner/nix_hook.go
+new file mode 100644
+index 000000000..fab111d6f
+--- /dev/null
++++ i/client/allocrunner/taskrunner/nix_hook.go
+@@ -0,0 +1,295 @@
++package taskrunner
++
++import (
++	"context"
++	"fmt"
++	"io"
++	"os"
++	"os/exec"
++	"path/filepath"
++	"strings"
++	"syscall"
++
++	hclog "github.com/hashicorp/go-hclog"
++	log "github.com/hashicorp/go-hclog"
++	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
++	"github.com/hashicorp/nomad/nomad/structs"
++)
++
++const (
++	// HookNameNix is the name of the Nix hook
++	HookNameNix = "nix"
++)
++
++// nixHook is used to prepare a task directory structure based on a Nix flake
++type nixHook struct {
++	alloc    *structs.Allocation
++	runner   *TaskRunner
++	logger   log.Logger
++	firstRun bool
++}
++
++func newNixHook(runner *TaskRunner, logger log.Logger) *nixHook {
++	h := &nixHook{
++		alloc:    runner.Alloc(),
++		runner:   runner,
++		firstRun: true,
++	}
++	h.logger = logger.Named(h.Name())
++	return h
++}
++
++func (*nixHook) Name() string {
++	return HookNameNix
++}
++
++func (h *nixHook) emitEvent(event string, message string) {
++	h.runner.EmitEvent(structs.NewTaskEvent(event).SetDisplayMessage(message))
++}
++
++func (h *nixHook) emitEventError(event string, err error) {
++	h.runner.EmitEvent(structs.NewTaskEvent(event).SetFailsTask().SetSetupError(err))
++}
++
++func (h *nixHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
++	first := h.firstRun
++	if first {
++		h.firstRun = false
++	} else {
++		return nil
++	}
++
++	flakes := []string{}
++	flakeArgs := []string{}
++
++	configFlakeDeps, flakeDepsSet := req.Task.Config["flake_deps"]
++	configFlake, flakeSet := req.Task.Config["flake"]
++	configFlakeArgs, flakeArgsSet := req.Task.Config["flake_args"]
++
++	if flakeDepsSet {
++		for _, dep := range configFlakeDeps.([]interface{}) {
++			flakes = append(flakes, dep.(string))
++		}
++	}
++
++	if flakeSet {
++		flakes = append(flakes, configFlake.(string))
++	}
++
++	if flakeArgsSet {
++		flakeArgs = configFlakeArgs.([]string)
++	}
++
++	if len(flakes) == 0 {
++		return nil
++	}
++
++	return h.install(flakes, flakeArgs, req.TaskDir.Dir)
++}
++
++// install takes a flake URL like:
++// github:NixOS/nixpkgs#cowsay
++// github:NixOS/nixpkgs?ref=nixpkgs-unstable#cowsay
++// github:NixOS/nixpkgs?rev=04b19784342ac2d32f401b52c38a43a1352cd916#cowsay
++//
++// the given flake
++func (h *nixHook) install(flakes []string, flakeArgs []string, taskDir string) error {
++	linkPath := filepath.Join(taskDir, "current-alloc")
++	_, err := os.Stat(linkPath)
++	if err == nil {
++		return nil
++	}
++
++	h.logger.Debug("Building flakes", "flake", flakes)
++	h.emitEvent("Nix", "building flakes: "+strings.Join(flakes, " "))
++
++	taskDirInfo, err := os.Stat(taskDir)
++	if err != nil {
++		return err
++	}
++
++	uid, gid := getOwner(taskDirInfo)
++
++	for _, flake := range flakes {
++		if err = h.profileInstall(linkPath, flake, flakeArgs); err != nil {
++			return err
++		}
++	}
++
++	requisites, err := h.requisites(linkPath)
++	if err != nil {
++		return err
++	}
++
++	// Now copy each dependency into the allocation /nix/store directory
++	for _, requisit := range requisites {
++		h.logger.Debug("linking", "requisit", requisit)
++
++		err = filepath.Walk(requisit, copyAll(h.logger, taskDir, false, uid, gid))
++		if err != nil {
++			return err
++		}
++	}
++
++	link, err := filepath.EvalSymlinks(linkPath)
++	if err != nil {
++		return err
++	}
++
++	h.logger.Debug("linking main drv paths", "linkPath", linkPath, "link", link)
++
++	return filepath.Walk(link, copyAll(h.logger, taskDir, true, uid, gid))
++}
++
++func (h *nixHook) profileInstall(linkPath string, flake string, flakeArgs []string) error {
++	h.logger.Debug("Building flake", "flake", flake)
++	h.emitEvent("Nix", "building flake: "+flake)
++
++	args := []string{"profile", "install", "--no-write-lock-file", "--profile", linkPath}
++	args = append(append(args, flakeArgs...), flake)
++	cmd := exec.Command("nix", args...)
++	output, err := cmd.CombinedOutput()
++
++	h.logger.Debug(cmd.String(), "output", string(output))
++
++	if err != nil {
++		h.logger.Error(cmd.String(), "output", string(output), "error", err)
++		h.emitEvent("Nix", "build failed with error: "+err.Error()+" output: "+string(output))
++		return err
++	}
++
++	return nil
++}
++
++func (h *nixHook) outPath(flake string, flakeArgs []string) (string, error) {
++	// Then get the path to the derivation output
++	args := []string{"eval", "--raw", "--apply", "(pkg: pkg.outPath)"}
++	args = append(append(args, flakeArgs...), flake)
++	cmd := exec.Command("nix", args...)
++	nixEvalOutput, err := cmd.Output()
++	path := string(nixEvalOutput)
++	h.logger.Debug(cmd.String(), "stdout", path)
++	if err != nil {
++		if ee, ok := err.(*exec.ExitError); ok {
++			h.logger.Error(cmd.String(), "error", err, "stderr", string(ee.Stderr))
++		} else {
++			h.logger.Error(cmd.String(), "error", err, "stdout", path)
++		}
++		return path, err
++	}
++
++	return path, nil
++}
++
++// Collect all store paths required to run it
++func (h *nixHook) requisites(outPath string) ([]string, error) {
++	cmd := exec.Command("nix-store", "--query", "--requisites", outPath)
++	nixStoreOutput, err := cmd.Output()
++
++	if err != nil {
++		if ee, ok := err.(*exec.ExitError); ok {
++			h.logger.Error(cmd.String(), "error", err, "stderr", string(ee.Stderr))
++		} else {
++			h.logger.Error(cmd.String(), "error", err, "stdout", string(nixStoreOutput))
++		}
++		return []string{}, err
++	}
++
++	return strings.Fields(string(nixStoreOutput)), nil
++}
++
++func copyAll(logger hclog.Logger, targetDir string, truncate bool, uid, gid int) filepath.WalkFunc {
++	return func(path string, info os.FileInfo, err error) error {
++		if err != nil {
++			return err
++		}
++
++		var dst string
++		if truncate {
++			parts := splitPath(path)
++			dst = filepath.Join(append([]string{targetDir}, parts[3:]...)...)
++		} else {
++			dst = filepath.Join(targetDir, path)
++		}
++
++		// Skip the file if it already exists at the dst
++		stat, err := os.Stat(dst)
++		lstat, _ := os.Lstat(dst)
++		if err == nil {
++			return nil
++		}
++		if !os.IsNotExist(err) {
++			logger.Debug("stat errors", "err", err, "stat",
++				fmt.Sprintf("%#v", stat),
++			)
++			return err
++		}
++
++		if info.Mode()&os.ModeSymlink != 0 {
++			link, err := os.Readlink(path)
++			if err != nil {
++				return err
++			}
++			// logger.Debug("l", "link", link, "dst", dst)
++			if err := os.Symlink(link, dst); err != nil {
++				if !os.IsExist(err) {
++					logger.Debug("stat", fmt.Sprintf("%#v", stat))
++					logger.Debug("lstat", fmt.Sprintf("%#v", lstat))
++					return err
++				}
++			}
++			if info.IsDir() {
++				return filepath.SkipDir
++			} else {
++				return nil
++			}
++		}
++
++		if info.IsDir() {
++			// logger.Debug("d", "dst", dst)
++			return os.MkdirAll(dst, 0777)
++		}
++
++		// logger.Debug("f", "dst", dst)
++		srcfd, err := os.Open(path)
++		if err != nil {
++			return err
++		}
++		defer srcfd.Close()
++
++		dstfd, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE, info.Mode())
++		if err != nil {
++			return err
++		}
++		defer dstfd.Close()
++
++		if _, err = io.Copy(dstfd, srcfd); err != nil {
++			return err
++		}
++
++		if err := dstfd.Chown(uid, gid); err != nil {
++			return fmt.Errorf("Couldn't copy %q to %q: %v", path, dst, err)
++		}
++
++		return nil
++	}
++}
++
++func getOwner(fi os.FileInfo) (int, int) {
++	stat, ok := fi.Sys().(*syscall.Stat_t)
++	if !ok {
++		return -1, -1
++	}
++	return int(stat.Uid), int(stat.Gid)
++}
++
++// SplitPath splits a file path into its directories and filename.
++func splitPath(path string) []string {
++	dir := filepath.Dir(path)
++	base := filepath.Base(path)
++	if dir == "/" {
++		return []string{base}
++	} else {
++		return append(splitPath(dir), base)
++	}
++}
+diff --git c/client/allocrunner/taskrunner/task_runner_hooks.go i/client/allocrunner/taskrunner/task_runner_hooks.go
+index 0789dd184..8a0303a82 100644
+--- c/client/allocrunner/taskrunner/task_runner_hooks.go
++++ i/client/allocrunner/taskrunner/task_runner_hooks.go
+@@ -82,6 +82,8 @@ func (tr *TaskRunner) initHooks() {
+ 			}))
+ 	}
+ 
++	tr.runnerHooks = append(tr.runnerHooks, newNixHook(tr, hookLogger))
++
+ 	// If Vault is enabled, add the hook
+ 	if task.Vault != nil {
+ 		tr.runnerHooks = append(tr.runnerHooks, newVaultHook(&vaultHookConfig{
+diff --git c/drivers/exec/driver.go i/drivers/exec/driver.go
+index eff9627ea..a2bd5794d 100644
+--- c/drivers/exec/driver.go
++++ i/drivers/exec/driver.go
+@@ -89,6 +89,9 @@ var (
+ 		"ipc_mode": hclspec.NewAttr("ipc_mode", "string", false),
+ 		"cap_add":  hclspec.NewAttr("cap_add", "list(string)", false),
+ 		"cap_drop": hclspec.NewAttr("cap_drop", "list(string)", false),
++		"flake":      hclspec.NewAttr("flake", "string", false),
++		"flake_args": hclspec.NewAttr("flake_args", "list(string)", false),
++		"flake_deps": hclspec.NewAttr("flake_deps", "list(string)", false),
+ 	})
+ 
+ 	// driverCapabilities represents the RPC response for what features are
+@@ -195,6 +198,7 @@ type TaskConfig struct {
+ 
+ 	// CapDrop is a set of linux capabilities to disable.
+ 	CapDrop []string `codec:"cap_drop"`
++	Flake   *string `codec:"flake"`
+ }
+ 
+ func (tc *TaskConfig) validate() error {


### PR DESCRIPTION
* This nomad version bump changes from raft 2 to raft 3 protocol.
* After upgrading, reverting back to v1.2.6 is not achievable without utilizing a state backup from 1.2.6, so ensure nomad state snapshot backups are available in the case of emergency.
* Docker jobs have not been observed to be adversely affected by the update in testing.
* After the upgrade on clients, until jobs are restarted, the nomad log will be spammed with cgroups messages.
* Restarting job allocations on clients after this upgrade to eliminate nomad log spamming is preferred but not a hard requirement.
* Includes CVE fix