### PR TITLE
fix(terraform): refer to sourceInfo attrs directly

### DIFF
--- a/modules/terraform.nix
+++ b/modules/terraform.nix
@@ -453,7 +453,7 @@
           type = with lib.types; attrsOf attrs;
           default =
             lib.mapAttrs (n: v: {
-              inherit (v.sourceInfo) lastModified lastModifiedDate narHash;
+              inherit (v) lastModified lastModifiedDate narHash;
 
               rev =
                 if v ? "rev"


### PR DESCRIPTION
bitte evaluations are failing for me right now because the `ops-lib` input doesn't have a `sourceInfo` attribute. This will be the case for any non-flake input.