### PR TITLE
Revert "Add `core-` prefix to clients iam role name"

### DIFF
--- a/modules/terraform/clients.nix
+++ b/modules/terraform/clients.nix
@@ -395,7 +395,7 @@ in {
       # deploy for core role
       inherit (config.cluster.iam.roles.client) uid;
     in {
-      "${uid}".name = "core-${uid}";
+      "${uid}".name = uid;
     };
 
     data.aws_iam_policy_document = let

--- a/modules/terraform/core.nix
+++ b/modules/terraform/core.nix
@@ -228,7 +228,7 @@ in {
       inherit (config.cluster.iam.roles) client core;
     in {
       "${client.uid}" = {
-        name = "core-${client.uid}";
+        name = client.uid;
         assume_role_policy = client.assumePolicy.tfJson;
         lifecycle = [{ create_before_destroy = true; }];
       };


### PR DESCRIPTION
This reverts commit 65ab1117a75af3cf979bf806b972b5f57dc3224c.

This commit seems to cause the `vault-agent` to fail:

```
Jul 27 06:36:22 ip-10-24-155-251.eu-central-1.compute.internal vault[736002]: 2022-07-27T06:36:22.248Z [INFO]  auth.handler: authenticating
Jul 27 06:36:22 ip-10-24-155-251.eu-central-1.compute.internal vault[736002]: 2022-07-27T06:36:22.635Z [ERROR] auth.handler: error authenticating:
Jul 27 06:36:22 ip-10-24-155-251.eu-central-1.compute.internal vault[736002]:   error=
Jul 27 06:36:22 ip-10-24-155-251.eu-central-1.compute.internal vault[736002]:   | Error making API request.
Jul 27 06:36:22 ip-10-24-155-251.eu-central-1.compute.internal vault[736002]:   |
Jul 27 06:36:22 ip-10-24-155-251.eu-central-1.compute.internal vault[736002]:   | URL: PUT https://vault.lw.iog.io/v1/auth/aws/login
Jul 27 06:36:22 ip-10-24-155-251.eu-central-1.compute.internal vault[736002]:   | Code: 400. Errors:
Jul 27 06:36:22 ip-10-24-155-251.eu-central-1.compute.internal vault[736002]:   |
Jul 27 06:36:22 ip-10-24-155-251.eu-central-1.compute.internal vault[736002]:   | * IAM Principal "arn:aws:sts::926093910549:assumed-role/core-lw-client/i-0023c9f46d55772b2" does not belong to the role "lw-client"
Jul 27 06:36:22 ip-10-24-155-251.eu-central-1.compute.internal vault[736002]:    backoff=40.67s
```
