### PR TITLE
consolidate vault policies into hydration

### DIFF
--- a/modules/terraform/hydrate-cluster/policies.nix
+++ b/modules/terraform/hydrate-cluster/policies.nix
@@ -16,7 +16,15 @@ Related to roles that are impersonated by humans.
 
   __fromTOML = builtins.fromTOML;
 
-  vaultPolicies = tfcfg.locals.policies.vault;
+  # necessary or some of these policies get deleted by terraform; eg routing
+  coreVaultPolicies =
+    builtins.removeAttrs
+    (import ../../../profiles/vault/policies.nix {inherit config lib;})
+    .services
+    .vault
+    .policies ["vault-agent-client" "vault-agent-core"];
+
+  vaultPolicies = coreVaultPolicies // tfcfg.locals.policies.vault;
   nomadPolicies = tfcfg.locals.policies.nomad;
   consulPolicies = tfcfg.locals.policies.consul;
 


### PR DESCRIPTION
Before there was a conflict between the policies set on the core machines at activation time, and the policies set by hydrate-cluster if the operator tried to add anything to these default policies. Specifically, the routing policy would always be deleted by terraform in a particular cluster due to a locally extended policy.

With this, we can ensure that terraform is aware of all of our defaut vault policies so rebuilding and/or hydrating doesn't unexpectedly change them.

This is a bit of a hack, but it's probably the best we can do until bitte is fully `std`ized.