### PR TITLE
Routing token fix

### DIFF
--- a/lib/mk-system/constants-module.nix
+++ b/lib/mk-system/constants-module.nix
@@ -46,7 +46,6 @@ in {
 
     hashiTokens = {
       vaultd-consul-json = "/etc/vault.d/consul-token.json";
-      nomadd-consul-json = "/etc/nomad.d/consul-token.json";
       consuld-json = "/etc/consul.d/tokens.json";
 
       vault = "/run/keys/vault-token";

--- a/modules/vault-agent.nix
+++ b/modules/vault-agent.nix
@@ -50,12 +50,6 @@
       };
     };
 in {
-  imports = [
-    (lib.mkRenamedOptionModule ["services" "vault-agent-core" "disableTokenRotation" "consulAgent"] ["services" "vault-agent" "disableTokenRotation" "consulAgent"])
-    (lib.mkRenamedOptionModule ["services" "vault-agent-core" "disableTokenRotation" "consulDefault"] ["services" "vault-agent" "disableTokenRotation" "consulDefault"])
-    (lib.mkRenamedOptionModule ["services" "vault-agent-client" "disableTokenRotation" "consulAgent"] ["services" "vault-agent" "disableTokenRotation" "consulAgent"])
-    (lib.mkRenamedOptionModule ["services" "vault-agent-client" "disableTokenRotation" "consulDefault"] ["services" "vault-agent" "disableTokenRotation" "consulDefault"])
-  ];
   options.services.vault-agent = {
     enable = lib.mkEnableOption "Enable the vault-agent";
 

--- a/modules/vault-agent.nix
+++ b/modules/vault-agent.nix
@@ -64,6 +64,9 @@ in {
             consulDefault =
               lib.mkEnableOption
               "Disable consul default token rotation on vault-agent-core nodes";
+            routing =
+              lib.mkEnableOption
+              "Disable traefik consul token rotation on routing";
           };
         };
     };

--- a/profiles/bootstrap/default.nix
+++ b/profiles/bootstrap/default.nix
@@ -76,13 +76,13 @@
     '';
 
   initialVaultStaticSecrets = let
-    mkStaticTokenCheck = policy: ''
+    mkStaticTokenCheck = policy: role: ''
       echo "Checking for ${policy} static token..."
-      if ! vault kv get -field token "kv/bootstrap/static-tokens/clients/${policy}" &> /dev/null; then
+      if ! vault kv get -field token "kv/bootstrap/static-tokens/${role}/${policy}" &> /dev/null; then
         echo "Creating ${policy} static token..."
         token="$(${mkStaticToken "${policy}"})"
         echo "Storing ${policy} static token in Vault secrets."
-        vault kv put "kv/bootstrap/static-tokens/clients/${policy}" token="$token"
+        vault kv put "kv/bootstrap/static-tokens/${role}/${policy}" token="$token"
       else
         echo "Found ${policy} static token."
       fi
@@ -96,10 +96,11 @@
     '';
   in ''
     set +x
-    ${mkStaticTokenCheck "consul-agent"}
-    ${mkStaticTokenCheck "consul-default"}
-    ${mkStaticTokenCheck "consul-server-agent"}
-    ${mkStaticTokenCheck "consul-server-default"}
+    ${mkStaticTokenCheck "consul-agent" "clients"}
+    ${mkStaticTokenCheck "consul-default" "clients"}
+    ${mkStaticTokenCheck "consul-server-agent" "core"}
+    ${mkStaticTokenCheck "consul-server-default" "core"}
+    ${mkStaticTokenCheck "traefik" "routing"}
     set -x
   '';
 in {

--- a/profiles/bootstrap/default.nix
+++ b/profiles/bootstrap/default.nix
@@ -165,22 +165,6 @@ in {
           systemctl restart consul.service
         fi
 
-        # # # # #
-        # Nomad #
-        # # # # #
-
-        if [ ! -s ${hashiTokens.nomadd-consul-json} ]; then
-          nomad="$(${mkToken "nomad-server" "nomad-server"})"
-
-          mkdir -p /etc/nomad.d
-
-          echo '{}' \
-          | jq --arg nomad "$nomad" '.consul.token = $nomad' \
-          > ${hashiTokens.nomadd-consul-json}.new
-
-          mv ${hashiTokens.nomadd-consul-json}.new ${hashiTokens.nomadd-consul-json}
-        fi
-
         ################
         # Extra Config #
         ################

--- a/profiles/consul/policies.nix
+++ b/profiles/consul/policies.nix
@@ -45,7 +45,9 @@
       };
 
       traefik = {
-        servicePrefix = allRead;
+        # Traefik utilization of Consul Connect catalog requires service write perms
+        # Ref: https://www.consul.io/api-docs/agent/connect#service-leaf-certificate
+        servicePrefix = allWrite;
         nodePrefix = allRead;
       };
 

--- a/profiles/routing.nix
+++ b/profiles/routing.nix
@@ -159,7 +159,7 @@ in {
       # This avoids a systemd service start race condition with NixOS service activation restart.
       # Ref: https://github.com/systemd/systemd/issues/20818#issuecomment-1172952498
       preStart = let
-        credFile = hashiTokens.consul-default;
+        credFile = hashiTokens.traefik;
       in ''
         echo "Checking for credentials file existence: ${credFile}"
         until [ -s ${credFile} ]; do
@@ -225,7 +225,7 @@ in {
             else cfg.staticConfigFile;
         in
           lib.mkForce (pkgs.writeShellScript "traefik.sh" ''
-            export CONSUL_HTTP_TOKEN="$(< ${hashiTokens.consul-default})"
+            export CONSUL_HTTP_TOKEN="$(< ${hashiTokens.traefik})"
             exec ${config.services.traefik.package}/bin/traefik --configfile=${staticConfigFile}
           '');
       };

--- a/profiles/vault/hydra.nix
+++ b/profiles/vault/hydra.nix
@@ -10,7 +10,10 @@
     ];
   };
 
-  Switches = {};
+  Switches = {
+    services.vault-agent.disableTokenRotation.consulAgent = true;
+    services.vault-agent.disableTokenRotation.consulDefault = true;
+  };
 
   Config = {
     services.vault-agent.role = "hydra";

--- a/profiles/vault/policies.nix
+++ b/profiles/vault/policies.nix
@@ -24,6 +24,11 @@ in {
         "consul/creds/consul-register" = [r];
         "consul/creds/consul-server-default" = [r];
         "consul/creds/consul-server-agent" = [r];
+        "kv/data/bootstrap/static-tokens/*" = [c r u d l];
+        "kv/data/bootstrap/*" = [r];
+        "kv/data/bootstrap/letsencrypt/cert" = [c r u d l];
+        "kv/data/bootstrap/letsencrypt/fullchain" = [c r u d l];
+        "kv/data/bootstrap/letsencrypt/key" = [c r u d l];
         "kv/data/system/alerts/*" = [r];
         "kv/metadata/system/alerts/*" = [l];
         "kv/data/system/dashboards/*" = [r];
@@ -122,6 +127,7 @@ in {
       "consul/creds/consul-default" = [r u];
       "consul/creds/consul-agent" = [r u];
       "consul/creds/consul-register" = [r];
+      "kv/data/bootstrap/static-tokens/clients/*" = [r];
     };
 
     routing.path = caps {
@@ -130,6 +136,8 @@ in {
       "consul/creds/consul-default" = [r u];
       "consul/creds/consul-agent" = [r u];
       "consul/creds/traefik" = [r u];
+      "kv/data/bootstrap/static-tokens/clients/*" = [r];
+      "kv/data/bootstrap/static-tokens/routing/*" = [r];
       "kv/data/bootstrap/letsencrypt/cert" = [c r u d l];
       "kv/data/bootstrap/letsencrypt/fullchain" = [c r u d l];
       "kv/data/bootstrap/letsencrypt/key" = [c r u d l];

--- a/profiles/vault/routing.nix
+++ b/profiles/vault/routing.nix
@@ -10,7 +10,11 @@
     ];
   };
 
-  Switches = {};
+  Switches = {
+    services.vault-agent.disableTokenRotation.consulAgent = true;
+    services.vault-agent.disableTokenRotation.consulDefault = true;
+    services.vault-agent.disableTokenRotation.routing = true;
+  };
 
   Config = {
     services.vault-agent.role = "routing";

--- a/profiles/vault/secrets-provisioning/hashistack.nix
+++ b/profiles/vault/secrets-provisioning/hashistack.nix
@@ -35,12 +35,6 @@
         {{- with secret "nomad/creds/nomad-autoscaler" }}{{ .Data.secret_id }}{{ end -}}'';
       nomadSnapshot = ''
         {{- with secret "nomad/creds/management" }}{{ .Data.secret_id }}{{ end -}}'';
-      nomadConsul = ''
-        {
-          "consul": {
-            "token": "${consulNomad}"
-          }
-        }
       '';
 
       consulAgent =
@@ -87,14 +81,6 @@
           {{ with secret "consul/creds/consul-default" }}{{ .Data.token }}{{ end }}'';
 
       consulNomad = consulDefault;
-
-      nomadConsul = ''
-        {
-          "consul": {
-            "token": "${consulNomad}"
-          }
-        }
-      '';
 
       consulACL = ''
         {
@@ -185,11 +171,6 @@ in {
       "${hashiTokens.consuld-json}" = lib.mkIf config.services.consul.enable {
         command = role.restart "consul.service";
         contents = role.consulACL;
-      };
-
-      "${hashiTokens.nomadd-consul-json}" = lib.mkIf (config.services.nomad.enable && isClient) {
-        command = role.restart "nomad.service";
-        contents = role.nomadConsul;
       };
 
       "${hashiTokens.traefik}" = lib.mkIf isRouting {

--- a/profiles/vault/secrets-provisioning/hashistack.nix
+++ b/profiles/vault/secrets-provisioning/hashistack.nix
@@ -35,19 +35,18 @@
         {{- with secret "nomad/creds/nomad-autoscaler" }}{{ .Data.secret_id }}{{ end -}}'';
       nomadSnapshot = ''
         {{- with secret "nomad/creds/management" }}{{ .Data.secret_id }}{{ end -}}'';
-      '';
 
       consulAgent =
         if config.services.vault-agent.disableTokenRotation.consulAgent
         then ''
-          {{ with secret "kv/bootstrap/static-tokens/cores/consul-server-agent" }}{{ .Data.data.token }}{{ end }}''
+          {{ with secret "kv/bootstrap/static-tokens/core/consul-server-agent" }}{{ .Data.data.token }}{{ end }}''
         else ''
           {{ with secret "consul/creds/consul-server-agent" }}{{ .Data.token }}{{ end }}'';
 
       consulDefault =
         if config.services.vault-agent.disableTokenRotation.consulDefault
         then ''
-          {{ with secret "kv/bootstrap/static-tokens/cores/consul-server-default" }}{{ .Data.data.token }}{{ end }}''
+          {{ with secret "kv/bootstrap/static-tokens/core/consul-server-default" }}{{ .Data.data.token }}{{ end }}''
         else ''
           {{ with secret "consul/creds/consul-server-default" }}{{ .Data.token }}{{ end }}'';
 
@@ -96,11 +95,18 @@
 
     routing = rec {
       inherit reload restart;
-      inherit (roles.client) consulAgent consulNomad;
-      consulDefault = ''
-        {{ with secret "consul/creds/consul-default" }}{{ .Data.token }}{{ end }}'';
-      traefik = ''{{ with secret "consul/creds/traefik" }}{{ .Data.token }}{{ end }}'';
+      inherit (roles.client) consulAgent consulDefault consulNomad;
 
+      traefik =
+        if config.services.vault-agent.disableTokenRotation.routing
+        then ''
+          {{ with secret "kv/bootstrap/static-tokens/routing/traefik" }}{{ .Data.data.token }}{{ end }}''
+        else ''
+          {{ with secret "consul/creds/traefik" }}{{ .Data.token }}{{ end }}'';
+
+      # Consul on routing excludes a default token for ACL security purposes.
+      # This has the side effect of preventing local consul DNS lookups on routing.
+      # Dnsmasq on routing is therefore configured to forward consul DNS requests to core nodes.
       consulACL = ''
         {
           "acl": {
@@ -114,10 +120,7 @@
 
     hydra = rec {
       inherit reload restart;
-      inherit (roles.client) consulAgent consulNomad;
-      consulDefault = ''
-        {{ with secret "consul/creds/consul-default" }}{{ .Data.token }}{{ end }}'';
-      traefik = ''{{ with secret "consul/creds/traefik" }}{{ .Data.token }}{{ end }}'';
+      inherit (roles.client) consulAgent consulDefault consulNomad;
 
       consulACL = ''
         {
@@ -134,7 +137,6 @@
 
   roleName = config.services.vault-agent.role;
   role = roles."${roleName}";
-  isClient = roleName == "client";
   isRouting = roleName == "routing";
 in {
   services.vault-agent = {
@@ -174,6 +176,7 @@ in {
       };
 
       "${hashiTokens.traefik}" = lib.mkIf isRouting {
+        command = role.restart "traefik.service";
         contents = role.traefik;
       };
     };


### PR DESCRIPTION
### Why:
* This will fix the 32 day consul related traefik failures which occur on routing due to the consul secret engine of vault not having periodic tokens (ie: renewable tokens past the default system max TTL).  Errors from this failure on router appear like the following examples:
```
# Consul service:

  [INFO]  agent.http: Request cancelled: method=GET url=/v1/agent/connect/ca/roots?dc=eu-central-1&index=12 from=127.0.0.1:44784 error="context canceled"
  [ERROR] agent.client: RPC failed to server: method=ConnectCA.Sign server=172.16.2.10:8300 error="rpc error making call: rpc error making call: ACL not found"
  [ERROR] agent.http: Request error: method=GET url=/v1/agent/connect/ca/leaf/traefik?dc=eu-central-1&index=2248521 from=127.0.0.1:44796 error="rpc error making call: rpc error making call: ACL not found"
  [ERROR] agent.client: RPC failed to server: method=Catalog.ListServices server=172.16.1.10:8300 error="rpc error making call: rpc error making call: ACL not found"
  [ERROR] agent.http: Request error: method=GET url=/v1/catalog/services?consistent=&dc=eu-central-1 from=127.0.0.1:44798 error="rpc error making call: rpc error making call: ACL not found"
  [INFO]  agent.http: Request cancelled: method=GET url=/v1/agent/connect/ca/roots?dc=eu-central-1&index=12 from=127.0.0.1:44792 error="context canceled"
  [ERROR] agent.client: RPC failed to server: method=Coordinate.Update server=172.16.2.10:8300 error="rpc error making call: rpc error making call: ACL not found"
  [ERROR] agent: Coordinate update error: error="rpc error making call: rpc error making call: ACL not found"
  [ERROR] agent.http: Request error: method=GET url=/v1/catalog/services?consistent=&dc=eu-central-1 from=127.0.0.1:44802 error="rpc error making call: rpc error making call: ACL not found"
  [INFO]  agent.http: Request cancelled: method=GET url=/v1/agent/connect/ca/leaf/traefik?dc=eu-central-1&index=2248521 from=127.0.0.1:44796 error="context canceled"
  [INFO]  agent.http: Request cancelled: method=GET url=/v1/agent/connect/ca/roots?dc=eu-central-1&index=12 from=127.0.0.1:44798 error="context canceled"
  [ERROR] agent.client: RPC failed to server: method=ConnectCA.Sign server=172.16.1.10:8300 error="rpc error making call: rpc error making call: ACL not found"

# Traefik service:
{"@level":"error","@message":"Watch errored","@module":"consulcatalog.watch","@timestamp":"2022-08-15T13:49:06.113669Z","error":"Unexpected response code: 403 (rpc error making call: ACL not found)","retry":5000000000,"type":"connect_leaf"}
  time="2022-08-15T13:49:06Z" level=error msg="Provider connection error failed to get consul catalog data: Unexpected response code: 403 (rpc error making call: ACL not found), retrying in 6.95333972s" providerName=consulcatalog
...
```

* Adds static `traefik-consul-token` generation, updated static kv paths, updated respective policies and corresponding utilization of consul static tokens.

### Migration:
* Metal deploy core-1 to update vault policies and push new static tokens to their associated kv paths.  Services will take a minute or so to restart successfully, so you may wish to use the no-auto-rollback, no-magic-rollback features of bitte deploy to avoid premature rollback.
* Metal deploy routing after core-1 deployment.  Ensure that vault-agent, consul, traefik have been restarted successfully after the deployment.
* For the few clusters which have additional hydrate-cluster policies for the routing role beyond the standard metal definitions, a hydrate-cluster plan/apply will need to be done.