### PR TITLE
cli: set flake `nixConfig` in deploy environment

### DIFF
--- a/nix/cli/packages/cli/Cargo.lock
+++ b/nix/cli/packages/cli/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "deploy-rs"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/deploy-rs#f81eb2b23291a0e3430703d92b6cbcefac7734d7"
+source = "git+https://github.com/input-output-hk/deploy-rs#4da8eb9fc3e611adf4bbe8c8df5b1fc604c4f906"
 dependencies = [
  "clap",
  "envmnt",

--- a/nix/cli/packages/cli/default.nix
+++ b/nix/cli/packages/cli/default.nix
@@ -31,7 +31,7 @@ in
     src = lib.cleanSource ./.;
     cargoLock.lockFile = ./Cargo.lock;
     cargoLock.outputHashes = {
-      "deploy-rs-0.1.0" = "sha256-X4eSLR1McUik0vDYWDCqIaWY1WjhIg4PIWXQ32WDFxg=";
+      "deploy-rs-0.1.0" = "sha256-+9P849WIb/zhAMWXrW9g0IRd7vFRj5a5acLTtOFyY48=";
     };
 
     nativeBuildInputs = [pkg-config];


### PR DESCRIPTION
One missing piece from my last PR, since deploy-rs builds `drv` files and not flake uri's, the `nixConfig` set in a flake.nix was ignored. This was pretty painful in Mamba, where it tried to build a lot of stuff that already exists in our S3 cache.

The implementation is here https://github.com/input-output-hk/deploy-rs/commit/4da8eb9fc3e611adf4bbe8c8df5b1fc604c4f906

Nix code adapted from the upstream nix daemon [module](https://github.com/NixOS/nixpkgs/blob/6039648c50c7c0858b5e506c6298773a98e0f066/nixos/modules/services/misc/nix-daemon.nix#L32-L61)

The basic implementation is to copy the nix code into the binary as a static string so that the nix cli can apply the transformation at runtime without needing to reference the library file living in the deploy-rs directory. 

We then search for a flake.nix in the current dir, or reursively upward through each parent dir until it is found, and then we simply call a `nix import` on the flake.nix, and if it contains a `nixConfig` attribute, we apply our static nix function to transform the attribute set into a "nix.conf" like string that can then be exported to the [`NIX_CONFIG`](https://nixos.org/manual/nix/stable/command-ref/conf-file.html) variable.