### PR TITLE
Patch consul for envoy route idle_timeout

### DIFF
--- a/pkgs/consul/consul-idle-timeout.patch
+++ b/pkgs/consul/consul-idle-timeout.patch
@@ -1,0 +1,49 @@
+diff --git i/agent/xds/config.go w/agent/xds/config.go
+index 020cefeb5..e672b97ce 100644
+--- i/agent/xds/config.go
++++ w/agent/xds/config.go
+@@ -38,6 +38,12 @@ type ProxyConfig struct {
+ 	// set.
+ 	LocalConnectTimeoutMs int `mapstructure:"local_connect_timeout_ms"`
+ 
++	// LocalIdleTimeoutMs is the number of milliseconds a request's stream to the
++	// local app instance may be idle. If not set, no value is set, Envoy defaults
++	// are respected, and an Envoy stream_idle_timeout (5m) will apply. If set,
++	// this LocalIdleTimeoutMs value will override the Envoy stream_idle_timeout.
++	LocalIdleTimeoutMs *int `mapstructure:"local_idle_timeout_ms"`
++
+ 	// LocalRequestTimeoutMs is the number of milliseconds to timeout HTTP requests
+ 	// to the local app instance. If not set, no value is set, Envoy defaults are
+ 	// respected (15s)
+diff --git i/agent/xds/listeners.go w/agent/xds/listeners.go
+index 319161ff4..b0b6a45df 100644
+--- i/agent/xds/listeners.go
++++ w/agent/xds/listeners.go
+@@ -837,6 +837,7 @@ func (s *ResourceGenerator) makeInboundListener(cfgSnap *proxycfg.ConfigSnapshot
+ 		filterName:       name,
+ 		routeName:        name,
+ 		cluster:          LocalAppClusterName,
++		idleTimeoutMs:    cfg.LocalIdleTimeoutMs,
+ 		requestTimeoutMs: cfg.LocalRequestTimeoutMs,
+ 	}
+ 	if useHTTPFilter {
+@@ -1347,6 +1348,7 @@ type listenerFilterOpts struct {
+ 	cluster          string
+ 	statPrefix       string
+ 	routePath        string
++	idleTimeoutMs    *int
+ 	requestTimeoutMs *int
+ 	ingressGateway   bool
+ 	httpAuthzFilter  *envoy_http_v3.HttpFilter
+@@ -1455,6 +1457,11 @@ func makeHTTPFilter(opts listenerFilterOpts) (*envoy_listener_v3.Filter, error)
+ 			},
+ 		}
+ 
++		if opts.idleTimeoutMs != nil {
++			r := route.GetRoute()
++			r.IdleTimeout = ptypes.DurationProto(time.Duration(*opts.idleTimeoutMs) * time.Millisecond)
++		}
++
+ 		if opts.requestTimeoutMs != nil {
+ 			r := route.GetRoute()
+ 			r.Timeout = ptypes.DurationProto(time.Duration(*opts.requestTimeoutMs) * time.Millisecond)

--- a/pkgs/consul/default.nix
+++ b/pkgs/consul/default.nix
@@ -35,6 +35,9 @@ buildGoModule rec {
     ./consul-issue-8283.patch
     # https://github.com/hashicorp/consul/issues/12145
     ./pr-12560-deregister-sunken-token.patch
+    # Add an envoy route idle_timeout config knob
+    # Follows: https://github.com/hashicorp/consul/pull/9554
+    ./consul-idle-timeout.patch
   ];
 
   passthru.tests.consul = nixosTests.consul;


### PR DESCRIPTION
* Adds a direct envoy control knob for connect proxy idle_timeout which also serves as an envoy stream_idle_timeout override
* Alternative escape hatches via Nomad do not seem to be available yet due to lack of dynamic port interpolation (https://github.com/hashicorp/nomad/issues/14403)