### PR TITLE
vault: allow devs to encrypt new secrets

### DIFF
--- a/modules/terraform/hydrate-cluster/policies-base.toml
+++ b/modules/terraform/hydrate-cluster/policies-base.toml
@@ -47,6 +47,7 @@ path."consul/creds/developer".capabilities = [ "read", "update", ] # Allow creat
 path."nomad/creds/developer".capabilities = [ "read", "update", ] # Allow creating Nomad tokens
 path."sops/keys/dev".capabilities = ["read", "list"] # Allow to decrypt dev sops secrets
 path."sops/decrypt/dev".capabilities = ["read", "update", "list"]
+path."sops/encrypt/dev".capabilities = ["read", "update", "list"]
 
 path."auth/token/lookup-self".capabilities = [ "read", ] # Allow lookup of own tokens
 path."auth/token/renew-self".capabilities = [ "update", ] # Allow self renewing tokens


### PR DESCRIPTION
Perhaps I am mistaken, but it seems the point of creating both an `ops` and `dev` key in the first place was to allow the devs more liberal access to their own secrets, while still protecting anything they shouldn't have access to with our own.

It seems to me to be overly restrictive to not allow devs to encrypt new secrets with a key they already have access to.