### PR TITLE
disable Nomad API rate limits

### DIFF
--- a/modules/nomad.nix
+++ b/modules/nomad.nix
@@ -1177,6 +1177,13 @@ in {
                 ${name} = [{config = [value];}];
               }));
     };
+
+    limits = with lib; mkOption {
+      type = types.submodule {
+        freeformType = types.attrs;
+      };
+      default = {};
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -1195,6 +1202,7 @@ in {
           consul
           server
           client
+          limits
           plugin
           telemetry
           vault

--- a/profiles/nomad/server.nix
+++ b/profiles/nomad/server.nix
@@ -55,6 +55,12 @@
           };
         };
       };
+
+      # https://github.com/hashicorp/nomad/issues/15471
+      limits = {
+        http_max_conns_per_client = 0;
+        rpc_max_conns_per_client = 0;
+      };
     };
 
     systemd.services.nomad.environment = {


### PR DESCRIPTION
I kept running into those because we're behind Traefik and from Nomad's perspective all requests come from the same IP.

This was typically triggered by toggling the eligibility of nomad clients in the web UI a few times or API requests from cicero's nomad component.

Also see: https://github.com/hashicorp/nomad/issues/15471